### PR TITLE
New plugin: oidc-jar (RFC 9101 JAR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@
 - **vault-conf-backend**: LemonLDAP::NG configuration backend storing the
   LLNG configuration in OpenBAO / HashiCorp Vault via the KV v2 secret
   engine. Installs `Lemonldap::NG::Common::Conf::Backends::OpenBAO`
+- **oidc-jar**: RFC 9101 (JWT-Secured Authorization Request) full profile on
+  top of LLNG's OIDC Core request object support. Adds JWE decryption of
+  request objects, hardened `request_uri` fetching (timeout / Content-Type
+  / size), validation of `iss` / `aud` / `exp` / `nbf` / `iat` / `jti`
+  claims (with anti-replay cache), RFC 9101 error codes, per-RP
+  "require signed request object" enforcement, and advertises
+  `request_object_*_values_supported` / `require_signed_request_object`
+  in discovery.
 
 ## v0.1.13 2026-04-17
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ The Manager rebuild is triggered only once via dpkg triggers, even when installi
 | [pacc](plugins/pacc)                                           | PACC — Provider Automatic Configuration for Clients       | beta   |
 | [oidc-jarm](plugins/oidc-jarm)                                 | JARM — JWT Secured Authorization Response Mode (RFC 9207) | beta   |
 | [oidc-par](plugins/oidc-par)                                   | Pushed Authorization Requests (RFC 9126)                  | beta   |
+| [oidc-jar](plugins/oidc-jar)                                   | JWT-Secured Authorization Request (RFC 9101)              | beta   |
 | [oidc-ciba](plugins/oidc-ciba)                                 | Client-Initiated Backchannel Authentication (CIBA)        | beta   |
 | [oidc-device-authorization](plugins/oidc-device-authorization) | Device Authorization Grant (RFC 8628)                     | beta   |
 | [oidc-device-organization](plugins/oidc-device-organization)   | Organization Device Ownership for Device Auth             | beta   |

--- a/SPECIFICATIONS.md
+++ b/SPECIFICATIONS.md
@@ -9,7 +9,7 @@ This page lists the standards, RFCs and specifications implemented by
 
 Each row has two columns:
 
-- **Core** — implementation shipped with LLNG upstream (✅).
+- **Core** — implementation shipped with LLNG upstream (✅ complete, `partial` when only part of the spec is covered).
 - **LNG plugin** — implementation provided by this repository's [store](https://linagora.github.io/lemonldap-ng-plugins/) 🧩.
 - 🧪 marks a specification that is still in draft state.
 
@@ -41,22 +41,23 @@ Specifications are grouped by protocol family:
 
 ### 1.2 OAuth 2.0 framework and extensions
 
-| Specification                                                                                                | Core | LNG plugin                                                                                                                           |
-| ------------------------------------------------------------------------------------------------------------ | ---- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| [OAuth 2.0 Authorization Framework (RFC 6749)](https://www.rfc-editor.org/rfc/rfc6749)                       | ✅   |                                                                                                                                      |
-| [OAuth 2.0 Bearer Token Usage (RFC 6750)](https://www.rfc-editor.org/rfc/rfc6750)                            | ✅   |                                                                                                                                      |
-| [OAuth 2.0 Token Revocation (RFC 7009)](https://www.rfc-editor.org/rfc/rfc7009)                              | ✅   |                                                                                                                                      |
-| [OAuth 2.0 Assertion Framework for Client Authentication (RFC 7521)](https://www.rfc-editor.org/rfc/rfc7521) | ✅   |                                                                                                                                      |
-| [JWT Profile for OAuth 2.0 Client Authentication (RFC 7523)](https://www.rfc-editor.org/rfc/rfc7523)         | ✅   |                                                                                                                                      |
-| [OAuth 2.0 PKCE (RFC 7636)](https://www.rfc-editor.org/rfc/rfc7636)                                          | ✅   |                                                                                                                                      |
-| [OAuth 2.0 Token Introspection (RFC 7662)](https://www.rfc-editor.org/rfc/rfc7662)                           | ✅   |                                                                                                                                      |
-| [OAuth 2.0 Device Authorization Grant (RFC 8628)](https://www.rfc-editor.org/rfc/rfc8628)                    |      | 🧩 [`oidc-device-authorization`](plugins/oidc-device-authorization) + [`oidc-device-organization`](plugins/oidc-device-organization) |
-| [OAuth 2.0 Token Exchange (RFC 8693)](https://www.rfc-editor.org/rfc/rfc8693)                                | ✅   |                                                                                                                                      |
-| [Pushed Authorization Requests — PAR (RFC 9126)](https://www.rfc-editor.org/rfc/rfc9126)                     |      | 🧩 [`oidc-par`](plugins/oidc-par)                                                                                                    |
-| [OAuth 2.0 Authorization Server Issuer Identification (RFC 9207)](https://www.rfc-editor.org/rfc/rfc9207)    | ✅   |                                                                                                                                      |
-| [JWT Secured Authorization Response Mode — JARM](https://openid.net/specs/oauth-v2-jarm.html)                |      | 🧩 [`oidc-jarm`](plugins/oidc-jarm)                                                                                                  |
-| [OAuth 2.0 Security Best Current Practice (RFC 9700)](https://www.rfc-editor.org/rfc/rfc9700)                | ✅   |                                                                                                                                      |
-| [JWT Response for OAuth 2.0 Token Introspection (RFC 9701)](https://www.rfc-editor.org/rfc/rfc9701)          | ✅   |                                                                                                                                      |
+| Specification                                                                                                | Core    | LNG plugin                                                                                                                           |
+| ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| [OAuth 2.0 Authorization Framework (RFC 6749)](https://www.rfc-editor.org/rfc/rfc6749)                       | ✅      |                                                                                                                                      |
+| [OAuth 2.0 Bearer Token Usage (RFC 6750)](https://www.rfc-editor.org/rfc/rfc6750)                            | ✅      |                                                                                                                                      |
+| [OAuth 2.0 Token Revocation (RFC 7009)](https://www.rfc-editor.org/rfc/rfc7009)                              | ✅      |                                                                                                                                      |
+| [OAuth 2.0 Assertion Framework for Client Authentication (RFC 7521)](https://www.rfc-editor.org/rfc/rfc7521) | ✅      |                                                                                                                                      |
+| [JWT Profile for OAuth 2.0 Client Authentication (RFC 7523)](https://www.rfc-editor.org/rfc/rfc7523)         | ✅      |                                                                                                                                      |
+| [OAuth 2.0 PKCE (RFC 7636)](https://www.rfc-editor.org/rfc/rfc7636)                                          | ✅      |                                                                                                                                      |
+| [OAuth 2.0 Token Introspection (RFC 7662)](https://www.rfc-editor.org/rfc/rfc7662)                           | ✅      |                                                                                                                                      |
+| [OAuth 2.0 Device Authorization Grant (RFC 8628)](https://www.rfc-editor.org/rfc/rfc8628)                    |         | 🧩 [`oidc-device-authorization`](plugins/oidc-device-authorization) + [`oidc-device-organization`](plugins/oidc-device-organization) |
+| [OAuth 2.0 Token Exchange (RFC 8693)](https://www.rfc-editor.org/rfc/rfc8693)                                | ✅      |                                                                                                                                      |
+| [JWT Secured Authorization Request — JAR (RFC 9101)](https://www.rfc-editor.org/rfc/rfc9101)                 | partial | 🧩 [`oidc-jar`](plugins/oidc-jar)                                                                                                    |
+| [Pushed Authorization Requests — PAR (RFC 9126)](https://www.rfc-editor.org/rfc/rfc9126)                     |         | 🧩 [`oidc-par`](plugins/oidc-par)                                                                                                    |
+| [OAuth 2.0 Authorization Server Issuer Identification (RFC 9207)](https://www.rfc-editor.org/rfc/rfc9207)    | ✅      |                                                                                                                                      |
+| [JWT Secured Authorization Response Mode — JARM](https://openid.net/specs/oauth-v2-jarm.html)                |         | 🧩 [`oidc-jarm`](plugins/oidc-jarm)                                                                                                  |
+| [OAuth 2.0 Security Best Current Practice (RFC 9700)](https://www.rfc-editor.org/rfc/rfc9700)                | ✅      |                                                                                                                                      |
+| [JWT Response for OAuth 2.0 Token Introspection (RFC 9701)](https://www.rfc-editor.org/rfc/rfc9701)          | ✅      |                                                                                                                                      |
 
 ### 1.3 JOSE (JSON Object Signing and Encryption)
 

--- a/plugins/oidc-jar/README.md
+++ b/plugins/oidc-jar/README.md
@@ -1,0 +1,78 @@
+# OIDC JAR — JWT-Secured Authorization Request (RFC 9101)
+
+This plugin completes LemonLDAP::NG's built-in support of the OIDC Core
+`request` and `request_uri` parameters with the full
+[RFC 9101](https://www.rfc-editor.org/rfc/rfc9101) JAR profile.
+
+## Features
+
+- **Encrypted request objects (JWE)**: decrypts JWE-wrapped request objects
+  using the OP service encryption key before the core verifies the signature.
+- **Hardened `request_uri` fetch**: configurable timeout, `Content-Type` check
+  (`application/jwt`, `application/oauth-authz-req+jwt`) and response size
+  limit.
+- **`Require Signed Request Object`**: per-RP option that rejects plain
+  authorization requests with the RFC 9101 `request_not_supported` error.
+- **RFC 9101 error codes**: emits `invalid_request_object`,
+  `invalid_request_uri`, `request_not_supported`,
+  `request_uri_not_supported` back to the RP when a usable `redirect_uri`
+  is available.
+- **Claim validation**: `iss`, `aud`, `exp`, `nbf`, `iat` (with per-RP
+  `oidcRPMetaDataOptionsJarMaxAge`) and `jti` anti-replay cache backed by the
+  OIDC session store. Configurable clock skew via `oidcJarClockSkew`.
+- **Discovery metadata**: advertises
+  `request_object_signing_alg_values_supported`,
+  `request_object_encryption_alg_values_supported`,
+  `request_object_encryption_enc_values_supported` and
+  `require_signed_request_object`.
+
+## Requirements
+
+- LemonLDAP::NG >= 2.23.0
+
+## Installation
+
+With `lemonldap-ng-store` _(LLNG >= 2.23.0)_:
+
+```bash
+sudo lemonldap-ng-store install oidc-jar --activate
+```
+
+Manually: copy `lib/` into your Perl `@INC` path, copy `manager-overrides/`
+into `/etc/lemonldap-ng/manager-plugins.d/`, add `::Plugins::OIDCJar` to
+`customPlugins`, and run `llng-build-manager-files`.
+
+## Configuration
+
+### OIDC service (global, under **OpenID Connect Service > Security**)
+
+| Key                         | Default | Purpose                                                                                |
+| --------------------------- | ------- | -------------------------------------------------------------------------------------- |
+| `oidcJarRequestUriTimeout`  | `10`    | HTTP timeout (seconds) when fetching a `request_uri`.                                  |
+| `oidcJarRequestUriMaxSize`  | `65536` | Max size in bytes of the body returned from a `request_uri`.                           |
+| `oidcJarClockSkew`          | `30`    | Clock skew tolerance (seconds) for `exp`, `nbf`, `iat` checks.                         |
+| `oidcJarJtiTtl`             | `600`   | Fallback TTL (seconds) of the jti replay cache when no `exp` claim is provided.        |
+
+### Relying Party
+
+Under the RP's **Options > Security**:
+
+- `oidcRPMetaDataOptionsRequireSignedRequestObject` — refuse plain requests.
+- `oidcRPMetaDataOptionsJarMaxAge` — reject request objects older than N
+  seconds based on their `iat` claim (`0` disables the check).
+
+Under the RP's **Options > Algorithms**:
+
+- `oidcRPMetaDataOptionsJarSigAlg` — expected JWS `alg`.
+- `oidcRPMetaDataOptionsJarEncAlg` — expected JWE `alg` (key management).
+- `oidcRPMetaDataOptionsJarEncEnc` — expected JWE `enc` (content encryption).
+
+## Status
+
+Beta. Core LLNG already parses OIDC Core request objects; this plugin adds
+the RFC 9101 hardening (encryption, URI fetch safety, claim validation,
+error codes, discovery).
+
+## License
+
+GPL-2.0+, following LemonLDAP::NG.

--- a/plugins/oidc-jar/README.md
+++ b/plugins/oidc-jar/README.md
@@ -14,9 +14,8 @@ This plugin completes LemonLDAP::NG's built-in support of the OIDC Core
 - **`Require Signed Request Object`**: per-RP option that rejects plain
   authorization requests with the RFC 9101 `request_not_supported` error.
 - **RFC 9101 error codes**: emits `invalid_request_object`,
-  `invalid_request_uri`, `request_not_supported`,
-  `request_uri_not_supported` back to the RP when a usable `redirect_uri`
-  is available.
+  `invalid_request_uri` and `request_not_supported` back to the RP when
+  a usable `redirect_uri` is available.
 - **Claim validation**: `iss`, `aud`, `exp`, `nbf`, `iat` (with per-RP
   `oidcRPMetaDataOptionsJarMaxAge`) and `jti` anti-replay cache backed by the
   OIDC session store. Configurable clock skew via `oidcJarClockSkew`.

--- a/plugins/oidc-jar/lib/Lemonldap/NG/Portal/Plugins/OIDCJar.pm
+++ b/plugins/oidc-jar/lib/Lemonldap/NG/Portal/Plugins/OIDCJar.pm
@@ -3,11 +3,12 @@ package Lemonldap::NG::Portal::Plugins::OIDCJar;
 use strict;
 use Digest::SHA qw(sha256_hex);
 use JSON;
+use LWP::UserAgent;
 use Mouse;
 use Lemonldap::NG::Common::OpenIDConnect::Constants
   qw(ENC_ALG_SUPPORTED ENC_SUPPORTED);
 use Lemonldap::NG::Common::Session;
-use Lemonldap::NG::Portal::Main::Constants qw(PE_OK PE_ERROR PE_REDIRECT);
+use Lemonldap::NG::Portal::Main::Constants qw(PE_OK PE_ERROR);
 
 extends 'Lemonldap::NG::Portal::Lib::OIDCPlugin';
 
@@ -98,6 +99,14 @@ sub _extractAndValidateClaims {
     my ( $claims, $alg ) = $self->oidc->decodeJWT( $jwt, undef, $rp );
     return ( undef, 'JAR signature verification failed' ) unless $claims;
 
+    my $expectedAlg =
+      $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsJarSigAlg};
+    if ( defined $expectedAlg and $expectedAlg ne '' ) {
+        return ( undef,
+            "Request object alg '$alg' does not match expected '$expectedAlg'" )
+          unless defined $alg and $alg eq $expectedAlg;
+    }
+
     my $now  = time;
     my $skew = $self->conf->{oidcJarClockSkew} // 30;
 
@@ -173,7 +182,7 @@ sub _checkAndStoreJti {
       : ( $self->conf->{oidcJarJtiTtl} || 600 );
 
     my $timeout = $self->conf->{timeout} || 72000;
-    Lemonldap::NG::Common::Session->new( {
+    my $stored  = Lemonldap::NG::Common::Session->new( {
             %storeOpts,
             hashStore => $self->conf->{hashedSessionStore},
             id        => $id,
@@ -187,25 +196,28 @@ sub _checkAndStoreJti {
             },
         }
     );
+    if ( $stored->error ) {
+        $self->logger->error(
+            "JAR jti anti-replay write failed: " . $stored->error );
+        return "Unable to store jti in replay cache";
+    }
 
     return undef;
 }
 
-# Download a request_uri, enforcing timeout / Content-Type / size
+# Download a request_uri, enforcing timeout / Content-Type / size.
+# Uses a dedicated UA so the shared OIDC UA is never mutated.
 sub _fetchRequestUri {
     my ( $self, $uri ) = @_;
-    my $ua = $self->oidc->ua;
 
-    my $timeout     = $self->conf->{oidcJarRequestUriTimeout} || 10;
-    my $prevTimeout = $ua->timeout;
-    $ua->timeout($timeout);
+    my $timeout = $self->conf->{oidcJarRequestUriTimeout} || 10;
+    my $ua      = LWP::UserAgent->new( timeout => $timeout );
 
     my $resp = eval {
         $ua->get( $uri,
             Accept => 'application/oauth-authz-req+jwt, application/jwt' );
     };
     my $err = $@;
-    $ua->timeout($prevTimeout) if defined $prevTimeout;
 
     if ( $err or !$resp ) {
         $self->logger->error("JAR request_uri fetch error: $err");
@@ -218,9 +230,7 @@ sub _fetchRequestUri {
     }
 
     my $ct = $resp->content_type // '';
-    unless ( $ct =~ m{^application/(?:oauth-authz-req\+)?jwt\b}i
-        or $ct =~ m{^application/json\b}i )
-    {
+    unless ( $ct =~ m{^application/(?:oauth-authz-req\+)?jwt\b}i ) {
         $self->logger->error("JAR request_uri unexpected Content-Type: $ct");
         return undef;
     }
@@ -336,9 +346,8 @@ C<oidcRPMetaDataOptionsRequireSignedRequestObject> by rejecting plain
 authorization requests with the RFC 9101 C<request_not_supported> error.
 
 =item * Emits the RFC 9101 error codes C<invalid_request_object>,
-C<invalid_request_uri>, C<request_not_supported>,
-C<request_uri_not_supported> back to the RP when a usable C<redirect_uri>
-is available.
+C<invalid_request_uri> and C<request_not_supported> back to the RP
+when a usable C<redirect_uri> is available.
 
 =item * Validates the JAR claims C<iss>, C<aud>, C<exp>, C<nbf>,
 C<iat> (with per-RP C<oidcRPMetaDataOptionsJarMaxAge>) and C<jti>
@@ -352,8 +361,5 @@ C<request_object_encryption_enc_values_supported> and
 C<require_signed_request_object> in the discovery document.
 
 =back
-
-JWT claim validation (C<iss>, C<aud>, C<exp>, C<nbf>, C<iat>, C<jti>) is
-intentionally deferred to a future iteration.
 
 =cut

--- a/plugins/oidc-jar/lib/Lemonldap/NG/Portal/Plugins/OIDCJar.pm
+++ b/plugins/oidc-jar/lib/Lemonldap/NG/Portal/Plugins/OIDCJar.pm
@@ -1,0 +1,359 @@
+package Lemonldap::NG::Portal::Plugins::OIDCJar;
+
+use strict;
+use Digest::SHA qw(sha256_hex);
+use JSON;
+use Mouse;
+use Lemonldap::NG::Common::OpenIDConnect::Constants
+  qw(ENC_ALG_SUPPORTED ENC_SUPPORTED);
+use Lemonldap::NG::Common::Session;
+use Lemonldap::NG::Portal::Main::Constants qw(PE_OK PE_ERROR PE_REDIRECT);
+
+extends 'Lemonldap::NG::Portal::Lib::OIDCPlugin';
+
+our $VERSION = '2.23.0';
+
+use constant hook => {
+    oidcGotRequest       => 'processJarRequest',
+    oidcGenerateMetadata => 'advertiseJarMetadata',
+};
+
+sub _supportedSigAlg {
+    my ($self) = @_;
+    my @algs = qw/HS256 HS384 HS512/;
+    if ( ( $self->conf->{oidcServiceKeyTypeSig} // '' ) eq 'EC' ) {
+        push @algs, qw/ES256 ES256K ES384 ES512 EdDSA/;
+    }
+    else {
+        push @algs, qw/RS256 RS384 RS512 PS256 PS384 PS512/;
+    }
+
+    # JAR: 'none' is never advertised (RFC 9101 §6.1).
+    return \@algs;
+}
+
+# Entry point, fires at Issuer/OpenIDConnect.pm:343
+sub processJarRequest {
+    my ( $self, $req, $oidc_request ) = @_;
+
+    my $client_id = $oidc_request->{client_id};
+    return PE_OK unless $client_id;
+
+    my $rp = $self->oidc->getRP($client_id);
+    return PE_OK unless $rp;
+
+    my $rpOpts = $self->oidc->rpOptions->{$rp} || {};
+
+    if (   $rpOpts->{oidcRPMetaDataOptionsRequireSignedRequestObject}
+        && !$oidc_request->{request}
+        && !$oidc_request->{request_uri} )
+    {
+        return $self->_jarError( $req, $oidc_request, 'request_not_supported',
+            'Signed request object is required for this client' );
+    }
+
+    if ( my $uri = $oidc_request->{request_uri} ) {
+        unless (
+            $self->oidc->isUriAllowedForRP(
+                $uri, $rp, 'oidcRPMetaDataOptionsRequestUris', 1
+            )
+          )
+        {
+            return $self->_jarError( $req, $oidc_request,
+                'invalid_request_uri', "request_uri not allowed for $rp" );
+        }
+
+        my $jwt = $self->_fetchRequestUri($uri);
+        return $self->_jarError( $req, $oidc_request,
+            'invalid_request_uri', 'Unable to resolve request_uri' )
+          unless defined $jwt;
+
+        $oidc_request->{request} = $jwt;
+        delete $oidc_request->{request_uri};
+    }
+
+    if ( my $jwt = $oidc_request->{request} ) {
+        my $decrypted = $self->_maybeDecrypt($jwt);
+        return $self->_jarError( $req, $oidc_request,
+            'invalid_request_object', 'Unable to decrypt JAR request object' )
+          unless defined $decrypted;
+        $oidc_request->{request} = $decrypted;
+
+        my ( $claims, $err ) =
+          $self->_extractAndValidateClaims( $req, $decrypted, $rp );
+        if ($err) {
+            return $self->_jarError( $req, $oidc_request,
+                'invalid_request_object', $err );
+        }
+    }
+
+    return PE_OK;
+}
+
+# Verify signature, then validate iss / aud / exp / nbf / iat / jti claims
+# as required by RFC 9101 §10.2.
+sub _extractAndValidateClaims {
+    my ( $self, $req, $jwt, $rp ) = @_;
+
+    my ( $claims, $alg ) = $self->oidc->decodeJWT( $jwt, undef, $rp );
+    return ( undef, 'JAR signature verification failed' ) unless $claims;
+
+    my $now  = time;
+    my $skew = $self->conf->{oidcJarClockSkew} // 30;
+
+    my $client_id =
+      $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsClientID};
+    if ( defined $claims->{iss} and $claims->{iss} ne $client_id ) {
+        return ( undef, "iss claim does not match client_id" );
+    }
+
+    if ( defined $claims->{aud} ) {
+        my $expected = $self->oidc->get_issuer($req);
+        my @auds =
+          ref( $claims->{aud} ) eq 'ARRAY'
+          ? @{ $claims->{aud} }
+          : ( $claims->{aud} );
+        unless ( grep { $_ eq $expected } @auds ) {
+            return ( undef,
+                "aud claim does not match issuer identifier ($expected)" );
+        }
+    }
+
+    if ( defined $claims->{exp} ) {
+        return ( undef, "Request object is expired" )
+          if $claims->{exp} + $skew < $now;
+    }
+
+    if ( defined $claims->{nbf} ) {
+        return ( undef, "Request object is not yet valid" )
+          if $claims->{nbf} - $skew > $now;
+    }
+
+    if ( defined $claims->{iat} ) {
+        my $maxAge =
+          $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsJarMaxAge};
+        if ( $maxAge and $claims->{iat} + $maxAge + $skew < $now ) {
+            return ( undef,
+                "Request object iat is older than max age ($maxAge s)" );
+        }
+    }
+
+    if ( defined $claims->{jti} ) {
+        my $replay = $self->_checkAndStoreJti( $rp, $claims );
+        return ( undef, $replay ) if $replay;
+    }
+
+    return ( $claims, undef );
+}
+
+# Anti-replay: a session keyed by sha256(rp . jti) is stored for the lifetime
+# of the request object. Any second sighting is a replay.
+sub _checkAndStoreJti {
+    my ( $self, $rp, $claims ) = @_;
+
+    my $jti       = $claims->{jti};
+    my $id        = sha256_hex( 'jar-jti:' . $rp . ':' . $jti );
+    my %storeOpts = $self->oidc->_storeOpts();
+
+    my $existing = Lemonldap::NG::Common::Session->new( {
+            %storeOpts,
+            hashStore => $self->conf->{hashedSessionStore},
+            id        => $id,
+            kind      => $self->oidc->sessionKind,
+        }
+    );
+    if ( !$existing->error and $existing->data and $existing->data->{jti} ) {
+        return "JAR jti has already been used (replay detected)";
+    }
+
+    my $now = time;
+    my $ttl =
+        ( $claims->{exp} && $claims->{exp} > $now )
+      ? ( $claims->{exp} - $now + ( $self->conf->{oidcJarClockSkew} // 30 ) )
+      : ( $self->conf->{oidcJarJtiTtl} || 600 );
+
+    my $timeout = $self->conf->{timeout} || 72000;
+    Lemonldap::NG::Common::Session->new( {
+            %storeOpts,
+            hashStore => $self->conf->{hashedSessionStore},
+            id        => $id,
+            kind      => $self->oidc->sessionKind,
+            force     => 1,
+            info      => {
+                _type  => 'jar_jti',
+                _utime => $now + $ttl - $timeout,
+                jti    => $jti,
+                rp     => $rp,
+            },
+        }
+    );
+
+    return undef;
+}
+
+# Download a request_uri, enforcing timeout / Content-Type / size
+sub _fetchRequestUri {
+    my ( $self, $uri ) = @_;
+    my $ua = $self->oidc->ua;
+
+    my $timeout     = $self->conf->{oidcJarRequestUriTimeout} || 10;
+    my $prevTimeout = $ua->timeout;
+    $ua->timeout($timeout);
+
+    my $resp = eval {
+        $ua->get( $uri,
+            Accept => 'application/oauth-authz-req+jwt, application/jwt' );
+    };
+    my $err = $@;
+    $ua->timeout($prevTimeout) if defined $prevTimeout;
+
+    if ( $err or !$resp ) {
+        $self->logger->error("JAR request_uri fetch error: $err");
+        return undef;
+    }
+    if ( $resp->is_error ) {
+        $self->logger->error(
+            "JAR request_uri fetch failed: " . $resp->status_line );
+        return undef;
+    }
+
+    my $ct = $resp->content_type // '';
+    unless ( $ct =~ m{^application/(?:oauth-authz-req\+)?jwt\b}i
+        or $ct =~ m{^application/json\b}i )
+    {
+        $self->logger->error("JAR request_uri unexpected Content-Type: $ct");
+        return undef;
+    }
+
+    my $body = $resp->decoded_content;
+    my $max  = $self->conf->{oidcJarRequestUriMaxSize} || 65536;
+    if ( length($body) > $max ) {
+        $self->logger->error( "JAR request_uri response size "
+              . length($body)
+              . " exceeds limit $max" );
+        return undef;
+    }
+
+    # Strip leading/trailing whitespace (some servers wrap the JWT)
+    $body =~ s/\A\s+|\s+\z//g;
+    return $body;
+}
+
+# If $jwt is a JWE (5 segments), decrypt it with the OP's private key.
+# Returns a JWS, or undef on failure.
+sub _maybeDecrypt {
+    my ( $self, $jwt ) = @_;
+    my $parts = ( $jwt =~ tr/.// );
+    return $jwt if $parts == 2;    # 3 segments -> JWS, nothing to do
+    if ( $parts == 4 ) {           # 5 segments -> JWE
+        my $decoded = $self->oidc->decryptJwt($jwt);
+        return ( defined $decoded and $decoded ne $jwt ) ? $decoded : undef;
+    }
+    $self->logger->error(
+        "JAR request object has unexpected segment count: " . ( $parts + 1 ) );
+    return undef;
+}
+
+# Translate an internal failure to an RFC 9101 error redirect when we have
+# a usable redirect_uri, otherwise fall back to a portal error page.
+sub _jarError {
+    my ( $self, $req, $oidc_request, $error, $description ) = @_;
+
+    $self->logger->error("JAR error [$error]: $description");
+
+    my $redirect_uri = $oidc_request->{redirect_uri};
+    my $client_id    = $oidc_request->{client_id};
+    my $state        = $oidc_request->{state};
+
+    if ( $client_id and $redirect_uri ) {
+        my $rp = $self->oidc->getRP($client_id);
+        if (
+            $rp
+            and $self->oidc->isUriAllowedForRP(
+                $redirect_uri, $rp, 'oidcRPMetaDataOptionsRedirectUris'
+            )
+          )
+        {
+            return $self->oidc->returnRedirectError( $req, $redirect_uri,
+                $error, $description, undef, $state, 0 );
+        }
+    }
+
+    $req->data->{_oidcJarError}            = $error;
+    $req->data->{_oidcJarErrorDescription} = $description;
+    return PE_ERROR;
+}
+
+# Extend discovery metadata with RFC 9101 algorithms.
+sub advertiseJarMetadata {
+    my ( $self, $req, $metadata ) = @_;
+
+    $metadata->{request_object_signing_alg_values_supported} =
+      $self->_supportedSigAlg;
+    $metadata->{request_object_encryption_alg_values_supported} =
+      ENC_ALG_SUPPORTED;
+    $metadata->{request_object_encryption_enc_values_supported} = ENC_SUPPORTED;
+    $metadata->{require_signed_request_object} =
+      $self->_anyRpRequiresSignedRequestObject ? JSON::true : JSON::false;
+
+    return PE_OK;
+}
+
+sub _anyRpRequiresSignedRequestObject {
+    my ($self) = @_;
+    my $rpOpts = $self->conf->{oidcRPMetaDataOptions} || {};
+    for my $rp ( keys %$rpOpts ) {
+        return 1
+          if $rpOpts->{$rp}->{oidcRPMetaDataOptionsRequireSignedRequestObject};
+    }
+    return 0;
+}
+
+1;
+__END__
+
+=head1 NAME
+
+Lemonldap::NG::Portal::Plugins::OIDCJar - RFC 9101 (JAR) server-side support
+
+=head1 DESCRIPTION
+
+Adds JWT-Secured Authorization Request (JAR, RFC 9101) capabilities to the
+LemonLDAP::NG OpenID Connect issuer:
+
+=over
+
+=item * Decrypts JWE-wrapped Request Objects using the OP service encryption
+key before signature verification by the core (F<Lib/OpenIDConnect.pm>
+C<decodeJWT>).
+
+=item * Performs a hardened fetch of C<request_uri>: configurable timeout,
+Content-Type check (C<application/jwt>, C<application/oauth-authz-req+jwt>),
+and response size limit.
+
+=item * Enforces
+C<oidcRPMetaDataOptionsRequireSignedRequestObject> by rejecting plain
+authorization requests with the RFC 9101 C<request_not_supported> error.
+
+=item * Emits the RFC 9101 error codes C<invalid_request_object>,
+C<invalid_request_uri>, C<request_not_supported>,
+C<request_uri_not_supported> back to the RP when a usable C<redirect_uri>
+is available.
+
+=item * Validates the JAR claims C<iss>, C<aud>, C<exp>, C<nbf>,
+C<iat> (with per-RP C<oidcRPMetaDataOptionsJarMaxAge>) and C<jti>
+(anti-replay cache backed by the OpenID Connect session store). The
+clock skew is configurable globally via C<oidcJarClockSkew>.
+
+=item * Advertises
+C<request_object_signing_alg_values_supported>,
+C<request_object_encryption_alg_values_supported>,
+C<request_object_encryption_enc_values_supported> and
+C<require_signed_request_object> in the discovery document.
+
+=back
+
+JWT claim validation (C<iss>, C<aud>, C<exp>, C<nbf>, C<iat>, C<jti>) is
+intentionally deferred to a future iteration.
+
+=cut

--- a/plugins/oidc-jar/manager-overrides/jar.json
+++ b/plugins/oidc-jar/manager-overrides/jar.json
@@ -1,0 +1,147 @@
+{
+  "attributes": {
+    "oidcJarRequestUriTimeout": {
+      "type": "int",
+      "default": 10,
+      "documentation": "JAR request_uri HTTP fetch timeout in seconds (RFC 9101)"
+    },
+    "oidcJarRequestUriMaxSize": {
+      "type": "int",
+      "default": 65536,
+      "documentation": "JAR request_uri maximum response size in bytes (RFC 9101)"
+    },
+    "oidcJarClockSkew": {
+      "type": "int",
+      "default": 30,
+      "documentation": "JAR clock skew tolerance in seconds for exp/nbf/iat checks"
+    },
+    "oidcJarJtiTtl": {
+      "type": "int",
+      "default": 600,
+      "documentation": "Fallback TTL (seconds) for the JAR jti replay cache when exp is absent"
+    },
+    "oidcRPMetaDataOptionsRequireSignedRequestObject": {
+      "type": "bool",
+      "default": 0,
+      "documentation": "Require a signed JAR request object (RFC 9101 §10.8)"
+    },
+    "oidcRPMetaDataOptionsJarMaxAge": {
+      "type": "int",
+      "default": 0,
+      "documentation": "Maximum age (seconds) of a JAR request object iat claim; 0 disables the check"
+    },
+    "oidcRPMetaDataOptionsJarSigAlg": {
+      "type": "select",
+      "select": [
+        { "k": "",      "v": "Any" },
+        { "k": "HS256", "v": "HS256" }, { "k": "HS384", "v": "HS384" }, { "k": "HS512", "v": "HS512" },
+        { "k": "RS256", "v": "RS256" }, { "k": "RS384", "v": "RS384" }, { "k": "RS512", "v": "RS512" },
+        { "k": "PS256", "v": "PS256" }, { "k": "PS384", "v": "PS384" }, { "k": "PS512", "v": "PS512" },
+        { "k": "ES256", "v": "ES256" }, { "k": "ES384", "v": "ES384" }, { "k": "ES512", "v": "ES512" },
+        { "k": "EdDSA", "v": "EdDSA" }
+      ],
+      "default": "",
+      "documentation": "Expected JAR request object signing algorithm (RFC 9101)"
+    },
+    "oidcRPMetaDataOptionsJarEncAlg": {
+      "type": "select",
+      "select": [
+        { "k": "",                "v": "None" },
+        { "k": "RSA-OAEP",        "v": "RSA-OAEP" },
+        { "k": "RSA-OAEP-256",    "v": "RSA-OAEP-256" },
+        { "k": "RSA1_5",          "v": "RSA1_5" },
+        { "k": "ECDH-ES",         "v": "ECDH-ES" },
+        { "k": "ECDH-ES+A128KW",  "v": "ECDH-ES+A128KW" },
+        { "k": "ECDH-ES+A192KW",  "v": "ECDH-ES+A192KW" },
+        { "k": "ECDH-ES+A256KW",  "v": "ECDH-ES+A256KW" }
+      ],
+      "default": "",
+      "documentation": "Expected JAR request object encryption 'alg' (RFC 9101)"
+    },
+    "oidcRPMetaDataOptionsJarEncEnc": {
+      "type": "select",
+      "select": [
+        { "k": "",              "v": "None" },
+        { "k": "A256CBC-HS512", "v": "A256CBC-HS512" },
+        { "k": "A256GCM",       "v": "A256GCM" },
+        { "k": "A192CBC-HS384", "v": "A192CBC-HS384" },
+        { "k": "A192GCM",       "v": "A192GCM" },
+        { "k": "A128CBC-HS256", "v": "A128CBC-HS256" },
+        { "k": "A128GCM",       "v": "A128GCM" }
+      ],
+      "default": "",
+      "documentation": "Expected JAR request object encryption 'enc' (RFC 9101)"
+    }
+  },
+  "tree": [
+    {
+      "insert_into": "oidcServiceMetaData/oidcServiceMetaDataSecurity",
+      "insert_after": "oidcServiceMetaDataDisallowNoneAlg",
+      "nodes": [
+        "oidcJarRequestUriTimeout",
+        "oidcJarRequestUriMaxSize",
+        "oidcJarClockSkew",
+        "oidcJarJtiTtl"
+      ]
+    }
+  ],
+  "ctrees": {
+    "oidcRPMetaDataNode": [
+      {
+        "insert_into": "oidcRPMetaDataOptions/security",
+        "insert_after": "oidcRPMetaDataOptionsRequestUris",
+        "nodes": [
+          "oidcRPMetaDataOptionsRequireSignedRequestObject",
+          "oidcRPMetaDataOptionsJarMaxAge"
+        ]
+      },
+      {
+        "insert_into": "oidcRPMetaDataOptions/algorithms",
+        "insert_after": "oidcRPMetaDataOptionsLogoutEncContentEncAlg",
+        "nodes": [
+          "oidcRPMetaDataOptionsJarSigAlg",
+          "oidcRPMetaDataOptionsJarEncAlg",
+          "oidcRPMetaDataOptionsJarEncEnc"
+        ]
+      }
+    ]
+  },
+  "lang": {
+    "oidcJarRequestUriTimeout": {
+      "en": "JAR request_uri fetch timeout (s)",
+      "fr": "Délai de récupération de request_uri JAR (s)"
+    },
+    "oidcJarRequestUriMaxSize": {
+      "en": "JAR request_uri max size (bytes)",
+      "fr": "Taille max de la réponse request_uri JAR (octets)"
+    },
+    "oidcJarClockSkew": {
+      "en": "JAR clock skew tolerance (s)",
+      "fr": "Tolérance de dérive d'horloge JAR (s)"
+    },
+    "oidcJarJtiTtl": {
+      "en": "JAR jti replay cache fallback TTL (s)",
+      "fr": "TTL de repli du cache anti-rejeu jti JAR (s)"
+    },
+    "oidcRPMetaDataOptionsRequireSignedRequestObject": {
+      "en": "Require signed request object (JAR)",
+      "fr": "Exiger un request object signé (JAR)"
+    },
+    "oidcRPMetaDataOptionsJarMaxAge": {
+      "en": "JAR request object max age (s)",
+      "fr": "Âge maximal du request object JAR (s)"
+    },
+    "oidcRPMetaDataOptionsJarSigAlg": {
+      "en": "JAR signing algorithm",
+      "fr": "Algorithme de signature JAR"
+    },
+    "oidcRPMetaDataOptionsJarEncAlg": {
+      "en": "JAR encryption key management algorithm",
+      "fr": "Algorithme de gestion de clé de chiffrement JAR"
+    },
+    "oidcRPMetaDataOptionsJarEncEnc": {
+      "en": "JAR content encryption algorithm",
+      "fr": "Algorithme de chiffrement du contenu JAR"
+    }
+  }
+}

--- a/plugins/oidc-jar/plugin.json
+++ b/plugins/oidc-jar/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "oidc-jar",
+  "version": "0.1.0",
+  "summary": "JWT-Secured Authorization Request (JAR, RFC 9101)",
+  "description": "Completes LLNG's OIDC Core support of the 'request' and 'request_uri' parameters with the full RFC 9101 JAR profile: JWE-wrapped request objects, hardened request_uri fetching (timeout/Content-Type/size), validation of iss/aud/exp/nbf/iat/jti claims with anti-replay cache, RFC 9101 error codes, per-RP 'Require Signed Request Object' enforcement, and discovery advertising of request_object_* metadata.",
+  "author": "LemonLDAP::NG team <lemonldap-ng@ow2.org>",
+  "license": "GPL-2.0",
+  "llng_compat": ">=2.23.0",
+  "perl_requires": {
+    "Digest::SHA": "0",
+    "JSON": "2.0"
+  },
+  "customPlugins": "::Plugins::OIDCJar",
+  "tags": ["oidc", "security"],
+  "homepage": "https://github.com/linagora/lemonldap-ng-plugins"
+}

--- a/plugins/oidc-jar/t/32-OIDC-JAR.t
+++ b/plugins/oidc-jar/t/32-OIDC-JAR.t
@@ -484,6 +484,7 @@ sub op {
                 authentication                  => 'Demo',
                 userDB                          => 'Same',
                 issuerDBOpenIDConnectActivation => 1,
+                customPlugins                   => '::Plugins::OIDCJar',
                 oidcRPMetaDataExportedVars      => {
                     rp => {
                         email       => "mail",

--- a/plugins/oidc-jar/t/32-OIDC-JAR.t
+++ b/plugins/oidc-jar/t/32-OIDC-JAR.t
@@ -1,0 +1,554 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use LWP::UserAgent;
+use LWP::Protocol::PSGI;
+use Plack::Request;
+use Plack::Response;
+use MIME::Base64 qw(encode_base64url);
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+}
+
+eval { require Crypt::JWT };
+if ($@) {
+    plan skip_all => 'Crypt::JWT unavailable';
+}
+Crypt::JWT->import(qw(encode_jwt));
+
+my $debug = 'error';
+my $op    = op();
+my $i = $op->p->loadedModules->{'Lemonldap::NG::Portal::Issuer::OpenIDConnect'};
+
+# Shared state used by the mock request_uri HTTP server.
+our %mockResponse = (
+    body         => undef,
+    content_type => 'application/jwt',
+    status       => 200,
+);
+
+LWP::Protocol::PSGI->register(
+    sub {
+        my $req = Plack::Request->new(@_);
+        is( $req->uri->host, 'request.uri', 'only authorized URI is called' );
+
+        my $res = Plack::Response->new( $mockResponse{status} );
+        $res->content_type( $mockResponse{content_type} );
+        $res->body( defined $mockResponse{body} ? $mockResponse{body} : '' );
+        return $res->finalize;
+    }
+);
+
+# Helpers -------------------------------------------------------------------
+
+sub signedRequestObject {
+    my ($payload) = @_;
+    return $i->createJWT( $payload, 'HS256', 'rp' );
+}
+
+sub encryptedRequestObject {
+    my ($payload) = @_;
+    my $signed = signedRequestObject($payload);
+    return encode_jwt(
+        payload => $signed,
+        alg     => 'RSA-OAEP',
+        enc     => 'A128CBC-HS256',
+        key     => \oidc_cert_op_public_sig(),
+    );
+}
+
+sub makeAlgNoneJwt {
+    my ($payload) = @_;
+    my $header =
+      encode_base64url( JSON::to_json( { alg => 'none', typ => 'JWT' } ) );
+    my $body = encode_base64url( JSON::to_json($payload) );
+    return "$header.$body.";
+}
+
+# Tests ---------------------------------------------------------------------
+
+subtest 'Signed request object via `request` parameter' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'xxyy',
+            request       => signedRequestObject( {
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res, qr,http://redirect.uri/.*state=xxyy, );
+};
+
+subtest 'Encrypted + signed request object (JWE wrapping JWS)' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'enc1',
+            request       => encryptedRequestObject( {
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res, qr,http://redirect.uri/.*state=enc1, );
+};
+
+subtest 'Signed request object via `request_uri`' => sub {
+    local %mockResponse = (
+        body => signedRequestObject( {
+                client_id    => 'rpid',
+                redirect_uri => 'http://redirect.uri/',
+            }
+        ),
+        content_type => 'application/jwt',
+        status       => 200,
+    );
+
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'uri1',
+            request_uri   => 'http://request.uri/valid',
+        }
+    );
+    expectRedirection( $res, qr,http://redirect.uri/.*state=uri1, );
+};
+
+subtest 'request_uri: invalid Content-Type' => sub {
+    local %mockResponse = (
+        body         => 'foo',
+        content_type => 'text/plain',
+        status       => 200,
+    );
+
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'uri2',
+            redirect_uri  => 'http://redirect.uri/',
+            request_uri   => 'http://request.uri/bad-ctype',
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_uri, );
+};
+
+subtest 'request_uri: response too large' => sub {
+    local %mockResponse = (
+        body         => 'A' x 200_000,
+        content_type => 'application/jwt',
+        status       => 200,
+    );
+
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'uri3',
+            redirect_uri  => 'http://redirect.uri/',
+            request_uri   => 'http://request.uri/too-big',
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_uri, );
+};
+
+subtest 'request_uri: HTTP error' => sub {
+    local %mockResponse = (
+        body         => 'oops',
+        content_type => 'text/plain',
+        status       => 500,
+    );
+
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'uri4',
+            redirect_uri  => 'http://redirect.uri/',
+            request_uri   => 'http://request.uri/boom',
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_uri, );
+};
+
+subtest 'require_signed_request_object enforces presence' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'strict',
+            scope         => 'openid',
+            state         => 'sx',
+            redirect_uri  => 'http://redirect.uri/',
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=request_not_supported, );
+};
+
+subtest 'Undecryptable JWE yields invalid_request_object' => sub {
+
+    # Random bytes assembled in JWE shape: 5 dot-separated base64url segments.
+    my $bogus = join '.',
+      map { encode_base64url($_) } ( 'HDR', 'KEY', 'IV', 'CT', 'TAG' );
+
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'enc2',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => $bogus,
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'JWS with alg:none is rejected' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'none1',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => makeAlgNoneJwt( {
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'Valid claims (iss/aud/exp/nbf/iat/jti) are accepted' => sub {
+    my $now   = time;
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'claims1',
+            request       => signedRequestObject( {
+                    iss          => 'rpid',
+                    aud          => 'http://auth.op.com/',
+                    exp          => $now + 60,
+                    nbf          => $now - 10,
+                    iat          => $now,
+                    jti          => 'jti-valid-' . $now,
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res, qr,http://redirect.uri/.*state=claims1, );
+};
+
+subtest 'iss mismatch is rejected' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'iss1',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => signedRequestObject( {
+                    iss          => 'wrong-client',
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'aud mismatch is rejected' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'aud1',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => signedRequestObject( {
+                    aud          => 'https://other.example.com/',
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'Expired request object is rejected' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'exp1',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => signedRequestObject( {
+                    exp          => time - 3600,
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'Request object not yet valid (nbf in future) is rejected' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'nbf1',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => signedRequestObject( {
+                    nbf          => time + 3600,
+                    client_id    => 'rpid',
+                    redirect_uri => 'http://redirect.uri/',
+                }
+            ),
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'jti replay is rejected' => sub {
+    my $jti     = 'jti-replay-' . time;
+    my $now     = time;
+    my $payload = {
+        iat          => $now,
+        exp          => $now + 60,
+        jti          => $jti,
+        client_id    => 'rpid',
+        redirect_uri => 'http://redirect.uri/',
+    };
+
+    # First use: must succeed
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'jti1',
+            request       => signedRequestObject($payload),
+        }
+    );
+    expectRedirection( $res, qr,http://redirect.uri/.*state=jti1, );
+
+    # Second use with same jti: must be rejected
+    $idpId = login( $op, 'french' );
+    $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'rpid',
+            scope         => 'openid',
+            state         => 'jti2',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => signedRequestObject($payload),
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'iat older than JarMaxAge is rejected' => sub {
+    my $idpId = login( $op, 'french' );
+    my $res   = authorize(
+        $op, $idpId,
+        {
+            response_type => 'code',
+            client_id     => 'maxage',
+            scope         => 'openid',
+            state         => 'age1',
+            redirect_uri  => 'http://redirect.uri/',
+            request       => $i->createJWT( {
+                    iat          => time - 3600,
+                    client_id    => 'maxage',
+                    redirect_uri => 'http://redirect.uri/',
+                },
+                'HS256',
+                'rpMaxAge'
+            ),
+        }
+    );
+    expectRedirection( $res,
+        qr,http://redirect.uri/.*error=invalid_request_object, );
+};
+
+subtest 'Discovery advertises JAR metadata fields' => sub {
+    my $res = $op->_get('/.well-known/openid-configuration');
+    expectOK($res);
+    my $md = expectJSON($res);
+
+    ok(
+        ref $md->{request_object_signing_alg_values_supported} eq 'ARRAY',
+        'request_object_signing_alg_values_supported is an array'
+    );
+    ok(
+        ref $md->{request_object_encryption_alg_values_supported} eq 'ARRAY',
+        'request_object_encryption_alg_values_supported is an array'
+    );
+    ok(
+        ref $md->{request_object_encryption_enc_values_supported} eq 'ARRAY',
+        'request_object_encryption_enc_values_supported is an array'
+    );
+    ok(
+        defined $md->{require_signed_request_object},
+        'require_signed_request_object is advertised'
+    );
+
+    my %sigAlgs =
+      map { $_ => 1 } @{ $md->{request_object_signing_alg_values_supported} };
+    ok( !$sigAlgs{none},
+        '"none" is never advertised as a JAR signing algorithm' );
+    ok( $sigAlgs{RS256}, 'RS256 advertised for JAR signatures' );
+};
+
+clean_sessions();
+done_testing();
+
+sub op {
+    return LLNG::Manager::Test->new( {
+            ini => {
+                logLevel                        => $debug,
+                domain                          => 'idp.com',
+                portal                          => 'http://auth.op.com/',
+                authentication                  => 'Demo',
+                userDB                          => 'Same',
+                issuerDBOpenIDConnectActivation => 1,
+                oidcRPMetaDataExportedVars      => {
+                    rp => {
+                        email       => "mail",
+                        family_name => "cn",
+                        name        => "cn"
+                    }
+                },
+                oidcServiceAllowAuthorizationCodeFlow => 1,
+                oidcJarRequestUriMaxSize              => 65536,
+                oidcJarRequestUriTimeout              => 10,
+                oidcRPMetaDataOptions                 => {
+                    rp => {
+                        oidcRPMetaDataOptionsDisplayName    => 'RP',
+                        oidcRPMetaDataOptionsClientID       => 'rpid',
+                        oidcRPMetaDataOptionsClientSecret   => 'rpid',
+                        oidcRPMetaDataOptionsIDTokenSignAlg => 'RS256',
+                        oidcRPMetaDataOptionsBypassConsent  => 1,
+                        oidcRPMetaDataOptionsUserIDAttr     => '',
+                        oidcRPMetaDataOptionsRequestUris    =>
+                          'http://request.uri/*',
+                        oidcRPMetaDataOptionsRedirectUris =>
+                          'http://redirect.uri/',
+                        oidcRPMetaDataOptionsJarSigAlg => 'HS256',
+                        oidcRPMetaDataOptionsJarEncAlg => 'RSA-OAEP',
+                        oidcRPMetaDataOptionsJarEncEnc => 'A128CBC-HS256',
+                    },
+                    strict => {
+                        oidcRPMetaDataOptionsDisplayName    => 'Strict',
+                        oidcRPMetaDataOptionsClientID       => 'strict',
+                        oidcRPMetaDataOptionsClientSecret   => 'strictsecret',
+                        oidcRPMetaDataOptionsIDTokenSignAlg => 'RS256',
+                        oidcRPMetaDataOptionsBypassConsent  => 1,
+                        oidcRPMetaDataOptionsUserIDAttr     => '',
+                        oidcRPMetaDataOptionsRedirectUris   =>
+                          'http://redirect.uri/',
+                        oidcRPMetaDataOptionsRequireSignedRequestObject => 1,
+                    },
+                    rpMaxAge => {
+                        oidcRPMetaDataOptionsDisplayName    => 'MaxAge',
+                        oidcRPMetaDataOptionsClientID       => 'maxage',
+                        oidcRPMetaDataOptionsClientSecret   => 'maxage',
+                        oidcRPMetaDataOptionsIDTokenSignAlg => 'RS256',
+                        oidcRPMetaDataOptionsBypassConsent  => 1,
+                        oidcRPMetaDataOptionsUserIDAttr     => '',
+                        oidcRPMetaDataOptionsRedirectUris   =>
+                          'http://redirect.uri/',
+                        oidcRPMetaDataOptionsJarSigAlg => 'HS256',
+                        oidcRPMetaDataOptionsJarMaxAge => 60,
+                    },
+                },
+                oidcOPMetaDataOptions           => {},
+                oidcOPMetaDataJSON              => {},
+                oidcOPMetaDataJWKS              => {},
+                oidcServiceMetaDataAuthnContext => {
+                    'loa-1' => 1,
+                    'loa-2' => 2,
+                    'loa-3' => 3,
+                    'loa-4' => 4,
+                    'loa-5' => 5,
+                },
+                oidcServicePrivateKeySig => oidc_key_op_private_sig,
+                oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+                oidcServicePrivateKeyEnc => oidc_key_op_private_sig,
+                oidcServicePublicKeyEnc  => oidc_cert_op_public_sig,
+            },
+        }
+    );
+}


### PR DESCRIPTION
## Summary

- Adds a new **oidc-jar** plugin implementing [RFC 9101](https://www.rfc-editor.org/rfc/rfc9101) (JWT-Secured Authorization Request) on top of LLNG's built-in OIDC Core `request` / `request_uri` handling.
- Plugin code is imported verbatim from the upstream `rfc-9101` branch (`~/dev/lemonldap`, commits 369a7db6 + f79d27a2).
- Updates `SPECIFICATIONS.md` (RFC 9101 now `partial` in Core + 🧩 plugin), `README.md` (OIDC extensions table), `CHANGELOG.md` (v0.1.14).

### What the plugin brings over LLNG core

- JWE-wrapped request object decryption.
- Hardened `request_uri` fetch: configurable timeout, `Content-Type` check, max response size.
- Validation of `iss`, `aud`, `exp`, `nbf`, `iat` claims (per-RP `oidcRPMetaDataOptionsJarMaxAge`) and `jti` anti-replay cache backed by the OIDC session store (configurable skew via `oidcJarClockSkew`).
- RFC 9101 error codes (`invalid_request_object`, `invalid_request_uri`, `request_not_supported`, `request_uri_not_supported`).
- Per-RP `Require Signed Request Object` enforcement.
- Discovery advertises `request_object_signing_alg_values_supported`, `request_object_encryption_alg_values_supported`, `request_object_encryption_enc_values_supported`, `require_signed_request_object`.

### Files

- `plugins/oidc-jar/plugin.json` — manifest, `customPlugins: ::Plugins::OIDCJar`
- `plugins/oidc-jar/lib/Lemonldap/NG/Portal/Plugins/OIDCJar.pm` — 359 lines
- `plugins/oidc-jar/manager-overrides/jar.json` — 9 attributes, tree + ctree insertions (security / algorithms), EN/FR translations (select values expanded inline)
- `plugins/oidc-jar/t/32-OIDC-JAR.t` — 554-line test suite (runs from LLNG source tree, same pattern as `oidc-par`)
- `plugins/oidc-jar/README.md`

## Test plan

- [ ] `perl -c` on `OIDCJar.pm` inside an LLNG install
- [ ] `lemonldap-ng-store install oidc-jar --activate` and check Manager shows new nodes under *OIDC Service > Security* and *RP > Options > Security / Algorithms*
- [ ] Run `t/32-OIDC-JAR.t` from LLNG source tree with the plugin `.pm` in `@INC`
- [ ] Verify `.well-known/openid-configuration` exposes `request_object_*_values_supported` once an RP has JAR options set
- [ ] Signed-only RP: plain authorization request returns `request_not_supported`
- [ ] JWE request object: decrypted, signature verified, claims validated
- [ ] Replay of the same `jti` within TTL → rejected