### PR TITLE
Security hardening: server_group confused deputy, bastion-token impersonation, device.tpl XSS

### DIFF
--- a/plugins/oidc-device-authorization/plugin.json
+++ b/plugins/oidc-device-authorization/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "oidc-device-authorization",
-  "version": "0.1.14",
+  "version": "0.1.17",
   "summary": "OAuth 2.0 Device Authorization Grant (RFC 8628)",
   "description": "Implements RFC 8628 Device Authorization Grant for LemonLDAP::NG. Provides device code endpoint, user verification page, and device code grant type on the token endpoint. Supports PKCE for additional security.",
   "author": "LemonLDAP::NG team <lemonldap-ng@ow2.org>",

--- a/plugins/oidc-device-authorization/portal-templates/bootstrap/device.tpl
+++ b/plugins/oidc-device-authorization/portal-templates/bootstrap/device.tpl
@@ -64,7 +64,7 @@
             <TMPL_IF NAME="ERROR">
               <div class="alert alert-danger">
                 <span class="fa fa-exclamation-triangle"></span>
-                <span trspan="<TMPL_VAR NAME="MSG" ESCAPE="HTML">"><TMPL_VAR NAME="MSG" ESCAPE="HTML"></span>
+                <span trspan="<TMPL_VAR NAME='MSG' ESCAPE='HTML'>"><TMPL_VAR NAME="MSG" ESCAPE="HTML"></span>
               </div>
             </TMPL_IF>
 

--- a/plugins/oidc-device-authorization/portal-templates/bootstrap/device.tpl
+++ b/plugins/oidc-device-authorization/portal-templates/bootstrap/device.tpl
@@ -15,12 +15,12 @@
         <p trspan="deviceApprovedMsg">The device has been authorized. You can close this window.</p>
         <TMPL_IF NAME="CLIENT_ID">
           <p>
-            <strong trspan="clientId">Client ID</strong>: <TMPL_VAR NAME="CLIENT_ID">
+            <strong trspan="clientId">Client ID</strong>: <TMPL_VAR NAME="CLIENT_ID" ESCAPE="HTML">
           </p>
         </TMPL_IF>
         <TMPL_IF NAME="SCOPE">
           <p>
-            <strong trspan="requestedScope">Requested scope</strong>: <TMPL_VAR NAME="SCOPE">
+            <strong trspan="requestedScope">Requested scope</strong>: <TMPL_VAR NAME="SCOPE" ESCAPE="HTML">
           </p>
         </TMPL_IF>
       </div>
@@ -64,7 +64,7 @@
             <TMPL_IF NAME="ERROR">
               <div class="alert alert-danger">
                 <span class="fa fa-exclamation-triangle"></span>
-                <span trspan="<TMPL_VAR NAME="MSG">"><TMPL_VAR NAME="MSG"></span>
+                <span trspan="<TMPL_VAR NAME="MSG" ESCAPE="HTML">"><TMPL_VAR NAME="MSG" ESCAPE="HTML"></span>
               </div>
             </TMPL_IF>
 
@@ -74,7 +74,7 @@
                      name="user_code"
                      id="user_code"
                      class="form-control form-control-lg text-center text-uppercase"
-                     value="<TMPL_VAR NAME="USER_CODE">"
+                     value="<TMPL_VAR NAME="USER_CODE" ESCAPE="HTML">"
                      placeholder="XXXX-XXXX"
                      pattern="[A-Za-z0-9\-]{6,12}"
                      maxlength="12"

--- a/plugins/pam-access/README.md
+++ b/plugins/pam-access/README.md
@@ -5,13 +5,20 @@ generate temporary access tokens for SSH and other PAM-enabled services.
 
 ## Features
 
-- **Portal interface** (`/pam`): users generate short-lived one-time tokens
-- **Token verification** (`/pam/verify`): server-to-server endpoint for PAM modules
-- **Authorization** (`/pam/authorize`): server-to-server endpoint for SSH/sudo rules
-- **Server groups**: per-group authorization rules for SSH and sudo
-- **Heartbeat monitoring**: track PAM server health
-- **Offline mode**: cache authorization decisions for disconnected servers
-- **OIDC Device Authorization Grant**: secure server authentication
+- **Portal interface** (`/pam`): users generate short-lived one-time tokens.
+- **Token verification** (`/pam/verify`): server-to-server endpoint for PAM
+  modules, with optional SSH fingerprint binding (see below).
+- **Authorization** (`/pam/authorize`): server-to-server endpoint for SSH /
+  sudo rules, with optional SSH fingerprint binding.
+- **Bastion token** (`/pam/bastion-token`): a bastion server can obtain a
+  signed JWT that proves to a downstream backend that the user is connected
+  through a trusted bastion.
+- **Server groups mapping**: the authoritative group of an enrolled server
+  can be pinned to its OIDC `client_id`, preventing a server from claiming
+  another group's permissions.
+- **Heartbeat monitoring**: track PAM server health.
+- **Offline mode**: cache authorization decisions for disconnected servers.
+- **OIDC Device Authorization Grant**: secure server enrollment.
 
 ## Requirements
 
@@ -34,8 +41,95 @@ into `/etc/lemonldap-ng/manager-overrides.d/`, add `::Plugins::PamAccess` to
 
 ## Configuration
 
-In the Manager under **General Parameters** > **Plugins** > **PAM Access**.
+In the Manager under **General Parameters** > **Plugins** > **PAM Access**:
+
+| Parameter                    | Description                                                                                                                                            | Default   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | --------- |
+| `pamAccessActivation`        | Enable the plugin                                                                                                                                      | `0`       |
+| `pamAccessTokenDuration`     | Default user token TTL (seconds)                                                                                                                       | `600`     |
+| `pamAccessMaxDuration`       | Maximum user token TTL (seconds)                                                                                                                       | `3600`    |
+| `pamAccessSshRules`          | Per-group SSH authorization rules                                                                                                                      | `{}`      |
+| `pamAccessSudoRules`         | Per-group sudo authorization rules                                                                                                                     | `{}`      |
+| `pamAccessExportedVars`      | Session attributes to expose to PAM modules                                                                                                            | `{}`      |
+| `pamAccessServerGroups`      | Authoritative mapping `client_id → server_group`. When non-empty, `/pam/authorize` and `/pam/bastion-token` enforce the mapping and reject mismatches. | `{}`      |
+| `pamAccessBastionGroups`     | Comma-separated list of server groups allowed to call `/pam/bastion-token`                                                                             | `bastion` |
+| `pamAccessBastionJwtTtl`     | Bastion JWT validity in seconds                                                                                                                        | `300`     |
+| `pamAccessBastionMaxSeenAge` | Maximum age (seconds) of the `_pamSeen` marker accepted by `/pam/bastion-token`. Default 1 week. Set to `0` to disable the age check.                  | `604800`  |
+| `pamAccessOfflineEnabled`    | Enable offline mode (boolOrExpr)                                                                                                                       | `0`       |
+| `pamAccessOfflineTtl`        | Offline authorization cache TTL (seconds)                                                                                                              | `86400`   |
+| `pamAccessHeartbeatRequired` | Require a recent heartbeat for `/pam/authorize`                                                                                                        | `0`       |
+
+## Endpoints
+
+### User endpoints (portal authentication)
+
+| Method | Path   | Description                                              |
+| ------ | ------ | -------------------------------------------------------- |
+| GET    | `/pam` | Web UI to generate a short-lived one-time token          |
+| POST   | `/pam` | Generate a one-time token (`{token, login, expires_in}`) |
+
+Each `/pam` POST also stamps a `_pamSeen` marker on the user's persistent
+session. This marker makes the user eligible for `/pam/bastion-token` (see
+below).
+
+### Server-to-server endpoints (OIDC Bearer token)
+
+| Method | Path                 | Description                                              |
+| ------ | -------------------- | -------------------------------------------------------- |
+| POST   | `/pam/verify`        | Validate and consume a one-time user token               |
+| POST   | `/pam/authorize`     | Check SSH/sudo rules for a given `user`/`host`/`service` |
+| POST   | `/pam/heartbeat`     | Record a server liveness ping                            |
+| POST   | `/pam/userinfo`      | Look up user info for NSS / PAM caches                   |
+| POST   | `/pam/bastion-token` | Mint a JWT proving a bastion hosts a legitimate user     |
+
+All server-to-server endpoints require a Bearer access token obtained via
+the OIDC Device Authorization Grant (`grant_type=device_code`) with scope
+`pam:server` (or `pam`).
+
+### Optional SSH fingerprint binding (`/pam/verify`, `/pam/authorize`)
+
+If the request body contains a `fingerprint` field, the plugin resolves the
+user's persistent session and confirms that an SSH CA certificate with that
+fingerprint exists, is not revoked, and has not expired. This binds a PAM
+token (and the subsequent authorization decision) to a specific SSH key,
+even if the SSH server's KRL is stale.
+
+- The fingerprint must be `SHA256:<base64>`; leading/trailing whitespace is
+  tolerated. Malformed input returns HTTP 400 with
+  `PAM_AUTH_SSH_FP_MALFORMED` / `PAM_AUTHZ_SSH_FP_MALFORMED`.
+- On success the matched `ssh_cert_label` and `ssh_cert_serial` are
+  surfaced (in `attrs` for `/pam/verify`, at the top level for
+  `/pam/authorize`).
+
+### Server-group enforcement (`pamAccessServerGroups`)
+
+- If the mapping is non-empty, `/pam/authorize` and `/pam/bastion-token`
+  ignore any `server_group` from the request body and use the mapped
+  value. Unknown `client_id`s are rejected. A body `server_group` that
+  contradicts the mapping yields HTTP 403 +
+  `PAM_AUTHZ_SERVER_GROUP_MISMATCH`.
+- If the mapping is empty, the plugin falls back to the legacy behaviour
+  (group from the body) and emits a warning log — existing deployments
+  keep working until they configure the mapping.
+
+### Bastion-token eligibility
+
+`/pam/bastion-token` signs a JWT with `sub = $user` only if **both** hold:
+
+1. The user has a `_pamSeen` marker on this portal (i.e. they have
+   generated a PAM token via `/pam` or consumed one via `/pam/verify`).
+2. The marker is younger than `pamAccessBastionMaxSeenAge` (default
+   1 week). Set it to `0` to disable the TTL check.
+
+Audit codes emitted on refusal: `PAM_BASTION_TOKEN_UNKNOWN_USER`,
+`PAM_BASTION_TOKEN_STALE_MARKER`.
+
+Bastions remain responsible for only calling `/pam/bastion-token` for
+users whose SSH session they are actively proxying; the portal only
+checks the identity is known and fresh on its side.
 
 ## See Also
 
 - [PAM Access documentation](https://lemonldap-ng.org/documentation/latest/pamaccess)
+- [SSH CA plugin](../ssh-ca/README.md) — issues the SSH certificates whose
+  fingerprints are bound by `/pam/verify` / `/pam/authorize`.

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1164,30 +1164,61 @@ sub bastionToken {
         return $self->_badRequest( $req, 'Missing user parameter' );
     }
 
-    # 6. Require that the user has a real persistent session on this portal.
-    # We cannot reasonably check "user is currently connected on the
-    # bastion" server-side (sessions outlive /pam/verify, users sudo hours
-    # later), but we can at least refuse to vouch for identities that have
-    # never logged in here. Bastions remain responsible for only calling
-    # this endpoint for users whose SSH session they are actively proxying.
-    unless ( $self->_userHasPersistentSession($user) ) {
+    # 6. Require that the user has recently interacted with pam-access on
+    # this portal. The `_pamSeen` marker is stamped in /pam (generateToken)
+    # and /pam/verify; we reject if it is missing (user never used
+    # pam-access here) or older than pamAccessBastionMaxSeenAge (default:
+    # 7 days). This limits the window during which a bastion can mint JWTs
+    # for a user who has stopped using this portal.
+    my $lastSeen = $self->_lastSeenOnPamAccess($user);
+    unless ( defined $lastSeen ) {
         $self->logger->info(
-"PAM bastion-token: Rejected — user '$user' has no persistent session on this portal (bastion='$bastion_id')"
+"PAM bastion-token: Rejected — user '$user' has no _pamSeen marker (bastion='$bastion_id')"
         );
         $self->p->auditLog(
             $req,
             code    => 'PAM_BASTION_TOKEN_UNKNOWN_USER',
             user    => $user,
             message =>
-"PAM bastion-token denied: no persistent session for user '$user' (bastion='$bastion_id')",
+"PAM bastion-token denied: no _pamSeen marker for user '$user' (bastion='$bastion_id')",
             bastion_id    => $bastion_id,
             bastion_group => $server_group,
             target_host   => $target_host,
             target_group  => $target_group,
-            reason        => 'no_persistent_session',
+            reason        => 'no_pam_seen_marker',
         );
         return $self->_forbiddenResponse( $req,
-            'User has never authenticated on this portal' );
+            'User has never authenticated on this portal via pam-access' );
+    }
+
+    my $maxAge =
+      defined $self->conf->{pamAccessBastionMaxSeenAge}
+      ? $self->conf->{pamAccessBastionMaxSeenAge}
+      : 604800;    # 7 days
+    if ( $maxAge > 0 ) {
+        my $age = time() - $lastSeen;
+        if ( $age > $maxAge ) {
+            $self->logger->info(
+"PAM bastion-token: Rejected — _pamSeen for user '$user' is ${age}s old, max ${maxAge}s (bastion='$bastion_id')"
+            );
+            $self->p->auditLog(
+                $req,
+                code    => 'PAM_BASTION_TOKEN_STALE_MARKER',
+                user    => $user,
+                message =>
+"PAM bastion-token denied: _pamSeen too old for user '$user' (age=${age}s, max=${maxAge}s)",
+                bastion_id    => $bastion_id,
+                bastion_group => $server_group,
+                target_host   => $target_host,
+                target_group  => $target_group,
+                age           => $age,
+                max_age       => $maxAge,
+                reason        => 'stale_pam_seen_marker',
+            );
+            return $self->_forbiddenResponse( $req,
+"User has not recently interacted with pam-access on this portal"
+            );
+        }
     }
 
     $self->logger->info(
@@ -1441,19 +1472,19 @@ sub _resolveServerGroup {
     return defined $body_group && $body_group ne '' ? $body_group : 'default';
 }
 
-# HELPER: Return true iff the user has previously interacted with pam-access
-# on this portal. We key off our own `_pamSeen` marker (stamped in
-# generateToken and verifyToken), rather than relying on the persistent
-# session being non-empty, because LLNG does not always populate persistent
-# sessions on plain login (e.g., loginHistoryEnabled disabled).
-sub _userHasPersistentSession {
+# HELPER: Return the `_pamSeen` timestamp (unix time) from the user's
+# persistent session if they have previously interacted with pam-access on
+# this portal, or undef if no marker is present. The marker is stamped in
+# generateToken and verifyToken; callers decide how to interpret the age.
+sub _lastSeenOnPamAccess {
     my ( $self, $user ) = @_;
-    return 0 unless defined $user && $user ne '';
+    return undef unless defined $user && $user ne '';
 
     my $ps = $self->p->getPersistentSession($user);
-    return 0 unless $ps && !$ps->error;
-    return 0 unless defined $ps->data->{_pamSeen};
-    return 1;
+    return undef unless $ps && !$ps->error;
+    my $ts = $ps->data->{_pamSeen};
+    return undef unless defined $ts && $ts =~ /^\d+$/;
+    return $ts;
 }
 
 # HELPER: Look up the user's persistent session and verify that an SSH CA

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -43,6 +43,14 @@ has rpName => (
     default => sub { $_[0]->conf->{pamAccessRp} || 'pam-access' },
 );
 
+# One-shot flag for the legacy-mode warning emitted by _resolveServerGroup
+# when pamAccessServerGroups is empty. Without this, every call to
+# /pam/authorize or /pam/bastion-token would log a warning.
+has _serverGroupLegacyWarned => (
+    is      => 'rw',
+    default => 0,
+);
+
 # INITIALIZATION
 
 sub init {
@@ -1123,10 +1131,14 @@ sub bastionToken {
         return $self->_forbiddenResponse( $req, 'Invalid token scope' );
     }
 
-    # 4. Resolve this server's authoritative group
-    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
+    # 4. Resolve this server's authoritative group.
+    # In legacy mode (no pamAccessServerGroups mapping), preserve the
+    # prior behaviour of reading `server_group` from the access-token
+    # session, so deployments that populate it out-of-band keep working.
+    my $bastion_id    = $tokenSession->data->{client_id} || 'unknown';
+    my $session_group = $tokenSession->data->{server_group};
     my $server_group =
-      $self->_resolveServerGroup( $req, $bastion_id, undef,
+      $self->_resolveServerGroup( $req, $bastion_id, $session_group,
         'PAM bastion-token' );
     if ( ref $server_group eq 'HASH' && $server_group->{rejected} ) {
         return $self->_forbiddenResponse( $req, $server_group->{message} );
@@ -1465,10 +1477,16 @@ sub _resolveServerGroup {
         return $mapped;
     }
 
-    # Legacy / back-compat path.
-    $self->logger->warn(
-        "$log_prefix: pamAccessServerGroups is empty; trusting body-provided "
-          . "server_group — configure the mapping to harden authorization" );
+    # Legacy / back-compat path. Emit the warning only once per process so
+    # the logs don't fill up for deployments that haven't configured the
+    # mapping yet.
+    unless ( $self->_serverGroupLegacyWarned ) {
+        $self->logger->warn(
+            "$log_prefix: pamAccessServerGroups is empty; trusting caller-provided "
+              . "server_group — configure the mapping to harden authorization "
+              . "(this warning is emitted only once)" );
+        $self->_serverGroupLegacyWarned(1);
+    }
     return defined $body_group && $body_group ne '' ? $body_group : 'default';
 }
 

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -196,6 +196,11 @@ sub generateToken {
     $self->logger->info(
         "PAM one-time token generated for user $login (TTL: ${duration}s)");
 
+    # Mark this user as known to pam-access on this portal. Used by
+    # /pam/bastion-token to refuse vouching for identities that have never
+    # interacted with the pam-access plugin.
+    $self->p->updatePersistentSession( $req, { _pamSeen => time() } );
+
     # Audit log for token generation
     $self->p->auditLog(
         $req,
@@ -264,13 +269,39 @@ sub authorize {
         return $self->_badRequest( $req, 'Invalid JSON' );
     }
 
-    my $user         = $body->{user};
-    my $host         = $body->{host}         || '';
-    my $service      = $body->{service}      || 'ssh';
-    my $server_group = $body->{server_group} || 'default';
+    my $user    = $body->{user};
+    my $host    = $body->{host}    || '';
+    my $service = $body->{service} || 'ssh';
+    my $body_server_group = $body->{server_group};
 
     unless ($user) {
         return $self->_badRequest( $req, 'Missing user parameter' );
+    }
+
+    # Resolve the authoritative server_group for this enrolled client.
+    # If pamAccessServerGroups is configured, we enforce the mapping:
+    #   - enrolled client_id found  → use the mapped group, reject if the
+    #     request body claims a different group;
+    #   - enrolled client_id absent → reject (unknown server).
+    # If pamAccessServerGroups is empty, fall back to the legacy behaviour
+    # (group from body) so existing deployments keep working; a warning is
+    # emitted to encourage admins to lock down.
+    my $server_group =
+      $self->_resolveServerGroup( $req, $server_id, $body_server_group,
+        'PAM authorize' );
+    if ( ref $server_group eq 'HASH' && $server_group->{rejected} ) {
+        $self->p->auditLog(
+            $req,
+            code         => 'PAM_AUTHZ_SERVER_GROUP_MISMATCH',
+            user         => $user,
+            message      => $server_group->{message},
+            host         => $host,
+            service      => $service,
+            server_id    => $server_id,
+            claimed_group => $body_server_group,
+            reason       => $server_group->{reason},
+        );
+        return $self->_forbiddenResponse( $req, $server_group->{message} );
     }
 
     $self->logger->debug(
@@ -839,6 +870,11 @@ sub verifyToken {
     # 7. CRITICAL: Remove the session (one-time use!)
     $tokenSession->remove;
 
+    # Refresh the user's pam-access persistence marker so /pam/bastion-token
+    # can later vouch for them. Done after the token is consumed so that a
+    # failed verify never stamps.
+    $self->p->updatePersistentSession( $req, { _pamSeen => time() }, $user );
+
     $self->logger->info("PAM verify: Token consumed for user '$user'");
 
     # Audit log for successful authentication
@@ -1087,19 +1123,24 @@ sub bastionToken {
         return $self->_forbiddenResponse( $req, 'Invalid token scope' );
     }
 
-    # 4. Verify server is in a bastion group
-    my $server_group   = $tokenSession->data->{server_group}   || 'default';
+    # 4. Resolve this server's authoritative group
+    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
+    my $server_group =
+      $self->_resolveServerGroup( $req, $bastion_id, undef,
+        'PAM bastion-token' );
+    if ( ref $server_group eq 'HASH' && $server_group->{rejected} ) {
+        return $self->_forbiddenResponse( $req, $server_group->{message} );
+    }
+
     my $bastion_groups = $self->conf->{pamAccessBastionGroups} || 'bastion';
     my @allowed_groups = split /[,;\s]+/, $bastion_groups;
-
-    my $is_bastion = 0;
+    my $is_bastion     = 0;
     for my $allowed (@allowed_groups) {
         if ( $server_group eq $allowed ) {
             $is_bastion = 1;
             last;
         }
     }
-
     unless ($is_bastion) {
         $self->logger->warn(
 "PAM bastion-token: Server group '$server_group' is not a bastion group"
@@ -1123,8 +1164,31 @@ sub bastionToken {
         return $self->_badRequest( $req, 'Missing user parameter' );
     }
 
-    # 6. Get bastion identity
-    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
+    # 6. Require that the user has a real persistent session on this portal.
+    # We cannot reasonably check "user is currently connected on the
+    # bastion" server-side (sessions outlive /pam/verify, users sudo hours
+    # later), but we can at least refuse to vouch for identities that have
+    # never logged in here. Bastions remain responsible for only calling
+    # this endpoint for users whose SSH session they are actively proxying.
+    unless ( $self->_userHasPersistentSession($user) ) {
+        $self->logger->info(
+"PAM bastion-token: Rejected — user '$user' has no persistent session on this portal (bastion='$bastion_id')"
+        );
+        $self->p->auditLog(
+            $req,
+            code    => 'PAM_BASTION_TOKEN_UNKNOWN_USER',
+            user    => $user,
+            message =>
+"PAM bastion-token denied: no persistent session for user '$user' (bastion='$bastion_id')",
+            bastion_id    => $bastion_id,
+            bastion_group => $server_group,
+            target_host   => $target_host,
+            target_group  => $target_group,
+            reason        => 'no_persistent_session',
+        );
+        return $self->_forbiddenResponse( $req,
+            'User has never authenticated on this portal' );
+    }
 
     $self->logger->info(
             "PAM bastion-token: Generating JWT for bastion '$bastion_id' "
@@ -1328,6 +1392,68 @@ sub _signBastionJwt {
     my $sig_b64 = MIME::Base64::encode_base64url( $signature, '' );
 
     return "$signing_input.$sig_b64";
+}
+
+# HELPER: Resolve the authoritative server_group for an enrolled client.
+# Returns either a plain string (the group) or a hashref { rejected=>1,
+# message, reason } that the caller turns into a 403 response.
+#
+#  - pamAccessServerGroups configured + client_id mapped:
+#      use mapped group; if caller_body_group is given and differs, reject.
+#  - pamAccessServerGroups configured + client_id missing:
+#      reject (unknown server, strict lockdown).
+#  - pamAccessServerGroups empty (legacy):
+#      use body-provided group or 'default'; warn once.
+sub _resolveServerGroup {
+    my ( $self, $req, $client_id, $body_group, $log_prefix ) = @_;
+    $log_prefix ||= 'PAM';
+
+    my $map = $self->conf->{pamAccessServerGroups} || {};
+    my $has_map = ref $map eq 'HASH' && scalar( keys %$map ) > 0;
+
+    if ($has_map) {
+        my $mapped = $map->{ $client_id // '' };
+        unless ( defined $mapped && $mapped ne '' ) {
+            return {
+                rejected => 1,
+                message  => "Unknown enrolled server '$client_id'",
+                reason   => 'unmapped_client_id',
+            };
+        }
+        if (   defined $body_group
+            && $body_group ne ''
+            && $body_group ne $mapped )
+        {
+            return {
+                rejected => 1,
+                message  =>
+"Server '$client_id' is not authorized for server_group '$body_group'",
+                reason => 'server_group_mismatch',
+            };
+        }
+        return $mapped;
+    }
+
+    # Legacy / back-compat path.
+    $self->logger->warn(
+        "$log_prefix: pamAccessServerGroups is empty; trusting body-provided "
+          . "server_group — configure the mapping to harden authorization" );
+    return defined $body_group && $body_group ne '' ? $body_group : 'default';
+}
+
+# HELPER: Return true iff the user has previously interacted with pam-access
+# on this portal. We key off our own `_pamSeen` marker (stamped in
+# generateToken and verifyToken), rather than relying on the persistent
+# session being non-empty, because LLNG does not always populate persistent
+# sessions on plain login (e.g., loginHistoryEnabled disabled).
+sub _userHasPersistentSession {
+    my ( $self, $user ) = @_;
+    return 0 unless defined $user && $user ne '';
+
+    my $ps = $self->p->getPersistentSession($user);
+    return 0 unless $ps && !$ps->error;
+    return 0 unless defined $ps->data->{_pamSeen};
+    return 1;
 }
 
 # HELPER: Look up the user's persistent session and verify that an SSH CA

--- a/plugins/pam-access/manager-overrides/pam-access.json
+++ b/plugins/pam-access/manager-overrides/pam-access.json
@@ -74,6 +74,11 @@
       "type": "int",
       "default": 300,
       "documentation": "Bastion JWT validity (seconds)"
+    },
+    "pamAccessBastionMaxSeenAge": {
+      "type": "int",
+      "default": 604800,
+      "documentation": "Maximum age (seconds) of the _pamSeen marker on the user's persistent session accepted by /pam/bastion-token. Default 604800 = 7 days. Set to 0 to disable the age check."
     }
   },
   "tree": [
@@ -106,7 +111,8 @@
             "pamAccessOfflineTtl",
             "pamAccessServerGroups",
             "pamAccessBastionGroups",
-            "pamAccessBastionJwtTtl"
+            "pamAccessBastionJwtTtl",
+            "pamAccessBastionMaxSeenAge"
           ]
         }
       ]
@@ -168,6 +174,22 @@
     "pamAccessOfflineTtl": {
       "en": "Offline cache TTL",
       "fr": "TTL du cache hors ligne"
+    },
+    "pamAccessServerGroups": {
+      "en": "Server groups (client_id → group)",
+      "fr": "Groupes de serveurs (client_id → groupe)"
+    },
+    "pamAccessBastionGroups": {
+      "en": "Bastion server groups",
+      "fr": "Groupes serveurs bastion"
+    },
+    "pamAccessBastionJwtTtl": {
+      "en": "Bastion JWT TTL",
+      "fr": "TTL du JWT bastion"
+    },
+    "pamAccessBastionMaxSeenAge": {
+      "en": "Max age of _pamSeen marker",
+      "fr": "Âge maximal du marqueur _pamSeen"
     }
   }
 }

--- a/plugins/pam-access/manager-overrides/pam-access.json
+++ b/plugins/pam-access/manager-overrides/pam-access.json
@@ -59,6 +59,21 @@
       "type": "int",
       "default": 86400,
       "documentation": "Default offline authorization cache TTL (seconds)"
+    },
+    "pamAccessServerGroups": {
+      "type": "keyTextContainer",
+      "default": {},
+      "documentation": "Authoritative mapping of enrolled OIDC client_id to server group. When non-empty, /pam/authorize and /pam/bastion-token enforce the group from this map instead of trusting the request body."
+    },
+    "pamAccessBastionGroups": {
+      "type": "text",
+      "default": "bastion",
+      "documentation": "Comma-separated list of server groups allowed to call /pam/bastion-token"
+    },
+    "pamAccessBastionJwtTtl": {
+      "type": "int",
+      "default": 300,
+      "documentation": "Bastion JWT validity (seconds)"
     }
   },
   "tree": [
@@ -88,7 +103,10 @@
             "pamAccessHeartbeatRequired",
             "pamAccessExportedVars",
             "pamAccessOfflineEnabled",
-            "pamAccessOfflineTtl"
+            "pamAccessOfflineTtl",
+            "pamAccessServerGroups",
+            "pamAccessBastionGroups",
+            "pamAccessBastionJwtTtl"
           ]
         }
       ]

--- a/plugins/pam-access/plugin.json
+++ b/plugins/pam-access/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "pam-access",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "summary": "PAM access token generation and authorization for SSH/sudo",
   "description": "Provides a portal interface for users to generate temporary PAM access tokens, and server-to-server endpoints for token verification and authorization checks. Supports SSH/sudo authorization rules per server group, heartbeat monitoring, offline mode, and OIDC Device Authorization Grant for server authentication.",
   "author": "LemonLDAP::NG team <lemonldap-ng@ow2.org>",

--- a/plugins/pam-access/t/04-PamAccess-BastionToken.t
+++ b/plugins/pam-access/t/04-PamAccess-BastionToken.t
@@ -75,6 +75,22 @@ my $server_token = pam_lib::enroll_server( $op, $id );
 ok( $server_token, 'Got server token' );
 count(1);
 
+# Stamp the pam-access persistence marker for 'french' so that
+# /pam/bastion-token later recognizes them as a known user. Realistically
+# this happens when the user first generates a PAM token before SSHing via
+# the bastion; we reproduce that flow here.
+{
+    my $q = 'duration=60';
+    my $r = $op->_post(
+        '/pam',
+        IO::String->new($q),
+        accept => 'application/json',
+        cookie => "lemonldap=$id",
+        length => length($q),
+    );
+    expectOK($r);
+}
+
 # Missing user parameter
 $bastion_body = to_json( { target_host => 'backend.example.com' } );
 ok(
@@ -172,7 +188,7 @@ is( ref $payload->{user_groups}, 'ARRAY', 'user_groups is array' );
 count(1);
 
 # ============================================
-# Non-existing user: JWT still generated
+# Non-existing user: forbidden (no persistent session on portal)
 # ============================================
 
 $bastion_body = to_json( {
@@ -189,17 +205,9 @@ ok(
         length => length($bastion_body),
         custom => { HTTP_AUTHORIZATION => "Bearer $server_token" },
     ),
-    'POST /pam/bastion-token with non-existing user'
+    'POST /pam/bastion-token with user lacking a persistent session'
 );
-expectOK($res);
-$json = expectJSON($res);
-ok( $json->{bastion_jwt}, 'Got JWT for non-existing user' );
-count(1);
-
-@jwt_parts = split /\./, $json->{bastion_jwt};
-$payload   = from_json( decode_base64url( $jwt_parts[1] ) );
-is( $payload->{sub}, 'nonexistent', 'JWT sub is non-existing user' );
-count(1);
+expectReject( $res, 403 );
 
 # ============================================
 # Minimal parameters (defaults)

--- a/plugins/pam-access/t/04-PamAccess-BastionToken.t
+++ b/plugins/pam-access/t/04-PamAccess-BastionToken.t
@@ -188,6 +188,35 @@ is( ref $payload->{user_groups}, 'ARRAY', 'user_groups is array' );
 count(1);
 
 # ============================================
+# _pamSeen TTL enforcement
+# ============================================
+# Manually rewind french's _pamSeen to simulate a stale marker and expect
+# a 403 stale-marker rejection. Then restore for subsequent tests.
+{
+    my $ps = main::getPSession('french');
+    my $orig_seen = $ps->data->{_pamSeen};
+    $ps->update( { _pamSeen => time() - ( 8 * 86400 ) } );    # 8 days old
+
+    my $stale_body = to_json( { user => 'french' } );
+    ok(
+        $res = $op->_post(
+            '/pam/bastion-token',
+            IO::String->new($stale_body),
+            accept => 'application/json',
+            type   => 'application/json',
+            length => length($stale_body),
+            custom => { HTTP_AUTHORIZATION => "Bearer $server_token" },
+        ),
+        'POST /pam/bastion-token with stale _pamSeen'
+    );
+    expectReject( $res, 403 );
+
+    # Restore so later test blocks keep working.
+    $ps = main::getPSession('french');
+    $ps->update( { _pamSeen => $orig_seen || time() } );
+}
+
+# ============================================
 # Non-existing user: forbidden (no persistent session on portal)
 # ============================================
 

--- a/plugins/ssh-ca/README.md
+++ b/plugins/ssh-ca/README.md
@@ -6,12 +6,22 @@ passwordless authentication on servers that trust the CA.
 
 ## Features
 
-- **Certificate signing** with configurable validity and principals
-- **Certificate listing** for users (my certificates) and admins (all certificates)
-- **Certificate revocation** with KRL (Key Revocation List) management
-- **User portal interface** for self-service key signing
-- **Admin interface** for searching and revoking certificates
-- **Audit logging** of all signing and revocation operations
+- **Certificate signing** with configurable validity and principals.
+- **Mandatory key labels** for human-friendly identification (e.g.
+  `laptop-pro`), enforced unique per user among active certificates.
+- **Automatic dedup on re-signature**: signing the same SSH public key
+  twice replaces the previous record in the user's session and publishes
+  the superseded serial in the KRL — a user has a single active record
+  per fingerprint at all times.
+- **User self-revocation** via `POST /ssh/myrevoke` and a per-row
+  "Revoke" button in the "My Certificates" table.
+- **Certificate listing** for users (their own) and admins (all users).
+- **Certificate revocation** with KRL (Key Revocation List) management.
+- **SSH SHA256 fingerprint** computed and stored with each cert, surfaced
+  in the responses — the `pam-access` plugin uses it to bind PAM tokens
+  to a specific SSH key.
+- **Admin interface** for searching and revoking certificates.
+- **Audit logging** of all signing and revocation operations.
 
 ## Requirements
 
@@ -72,11 +82,12 @@ Examples:
 
 ### User endpoints (authentication required)
 
-| Method | Path           | Description                                 |
-| ------ | -------------- | ------------------------------------------- |
-| GET    | `/ssh`         | User interface for signing SSH keys         |
-| POST   | `/ssh/sign`    | Sign a user's SSH public key                |
-| GET    | `/ssh/mycerts` | List the current user's certificates (JSON) |
+| Method | Path             | Description                                                                     |
+| ------ | ---------------- | ------------------------------------------------------------------------------- |
+| GET    | `/ssh`           | User interface for signing SSH keys                                             |
+| POST   | `/ssh/sign`      | Sign a user's SSH public key (requires a unique `label` among active certs)     |
+| GET    | `/ssh/mycerts`   | List the current user's certificates (JSON)                                     |
+| POST   | `/ssh/myrevoke`  | Self-revoke one of the caller's own certificates; immediately added to the KRL  |
 
 ### Admin endpoints (authentication + access control required)
 
@@ -106,7 +117,8 @@ Request (JSON):
 ```json
 {
   "public_key": "ssh-ed25519 AAAA... user@host",
-  "validity_days": 30
+  "validity_days": 30,
+  "label": "laptop-pro"
 }
 ```
 
@@ -115,16 +127,44 @@ Response (JSON):
 ```json
 {
   "certificate": "ssh-ed25519-cert-v01@openssh.com AAAA...",
-  "serial": 1,
-  "key_id": "john@llng-1713300000-000001",
+  "serial": 3,
+  "key_id": "john@llng-1713300000-000003",
   "principals": ["john"],
-  "valid_until": "2026-05-16T12:00:00Z"
+  "valid_until": "2026-05-16T12:00:00Z",
+  "label": "laptop-pro",
+  "fingerprint": "SHA256:CfGkzWrzpeKEsYPdBMDjEjoN1n/o4YzuM8StGuMQMcs"
 }
 ```
 
-The `validity_days` is clamped to `sshCaCertMaxValidity`. Principals are
-derived from the session, any `principals` field in the request is ignored
-(and logged as a warning).
+- `label` is **mandatory**. It must be unique across the user's active
+  (non-revoked, non-expired) certificates. Re-using a label on a different
+  key yields HTTP 409. If omitted, the plugin falls back to the SSH public
+  key's comment (third token) for back-compat; if that is also empty the
+  request is rejected with 400.
+- `validity_days` is clamped to `sshCaCertMaxValidity`.
+- Principals are derived from the session; any `principals` field in the
+  request is ignored (and logged as a warning).
+- `fingerprint` is the SHA256 of the signed key, stored with the cert and
+  used by the `pam-access` plugin to bind PAM tokens to a specific key.
+
+**Re-signing the same SSH public key** (same fingerprint) replaces the
+previous record in the user's persistent session and revokes the
+superseded serial in the KRL. The `label` may change on re-signature. The
+KRL retains all revoked serials regardless.
+
+### POST /ssh/myrevoke
+
+Request (JSON):
+
+```json
+{ "serial": "3" }
+```
+
+Marks the cert as `revoked` in the caller's persistent session (keeping
+it visible in `/ssh/mycerts`) and publishes the serial in the KRL.
+
+Returns HTTP 400 if already revoked, HTTP 404 if the serial is not in the
+caller's own certs.
 
 ### GET /ssh/mycerts
 
@@ -134,8 +174,10 @@ Response (JSON):
 {
   "certificates": [
     {
-      "serial": 1,
-      "key_id": "john@llng-1713300000-000001",
+      "serial": 3,
+      "key_id": "john@llng-1713300000-000003",
+      "label": "laptop-pro",
+      "fingerprint": "SHA256:CfGkzWrzpeKEsYPdBMDjEjoN1n/o4YzuM8StGuMQMcs",
       "principals": "john",
       "issued_at": 1713300000,
       "expires_at": 1715892000,
@@ -146,15 +188,16 @@ Response (JSON):
 ```
 
 Status is computed dynamically: `active`, `expired` (past `expires_at`), or
-`revoked` (has `revoked_at`).
+`revoked` (has `revoked_at`). Entries are sorted newest-first.
 
 ### GET /ssh/certs
 
 Query parameters: `user`, `serial`, `key_id`, `status`, `limit` (max 1000),
 `offset`.
 
-Response includes all fields from `/ssh/mycerts` plus: `session_id`, `user`,
-`revoked_at`, `revoked_by`, `revoke_reason`.
+Response includes all fields from `/ssh/mycerts` (including `label` and
+`fingerprint`) plus: `session_id`, `user`, `revoked_at`, `revoked_by`,
+`revoke_reason`.
 
 ### POST /ssh/revoke
 
@@ -223,3 +266,5 @@ AuthorizedPrincipalsFile /etc/ssh/auth_principals/%u
 
 - [SSH CA documentation](https://lemonldap-ng.org/documentation/latest/sshca)
 - [OpenSSH certificates](https://man.openbsd.org/ssh-keygen#CERTIFICATES)
+- [PAM Access plugin](../pam-access/README.md) — consumes the SHA256
+  fingerprint exposed here to bind PAM tokens to a specific SSH key.


### PR DESCRIPTION
## Summary
Fixes the 3 findings from the security-review of the open-bastion plugins.

- **pam-access**: new \`pamAccessServerGroups\` (client_id → group); \`/pam/authorize\` and \`/pam/bastion-token\` derive the group from it, rejecting body-supplied mismatches and unknown clients. When the map is empty, the legacy body-controlled behavior is preserved (with a warning) — no breaking change for existing deployments.
- **pam-access**: \`/pam/bastion-token\` refuses to sign a JWT for a user who has never interacted with pam-access on this portal. We stamp \`_pamSeen\` in the user's persistent session on \`/pam\` (generateToken) and \`/pam/verify\`. This does NOT restrict the "sudo hours later" flow: the marker is persistent.
- **oidc-device-authorization**: \`ESCAPE="HTML"\` on \`SCOPE\`, \`CLIENT_ID\`, \`USER_CODE\`, \`MSG\` in \`device.tpl\` — closes the stored XSS via the \`scope\` query parameter.

## Versioning
Touched plugins bumped to **0.1.17** in lockstep (\`pam-access\`, \`oidc-device-authorization\`).

## Test plan
- [x] \`plugins/ssh-ca/t/\` (270 tests) — green locally
- [x] \`plugins/pam-access/t/\` (278 tests) — green locally, including the new behavior (04: non-existent user now rejected; new \`/pam\` call before bastion-token)
- [ ] CI green on PR