### PR TITLE
store: add authPlugin declaration for auth modules

### DIFF
--- a/plugins/json-file/manager-overrides/json-file.json
+++ b/plugins/json-file/manager-overrides/json-file.json
@@ -1,17 +1,10 @@
 {
+    "authPlugin": {
+        "k": "JsonFile",
+        "v": "JSON File (dev/test)",
+        "roles": ["authentication", "userDB"]
+    },
     "attributes": {
-        "authentication": {
-            "type": "select",
-            "select": [
-                { "k": "JsonFile", "v": "JSON File (dev/test)" }
-            ]
-        },
-        "userDB": {
-            "type": "select",
-            "select": [
-                { "k": "JsonFile", "v": "JSON File (dev/test)" }
-            ]
-        },
         "jsonFileUserPath": {
             "type": "text",
             "default": "",

--- a/store/scripts/llng-build-manager-files
+++ b/store/scripts/llng-build-manager-files
@@ -170,10 +170,16 @@ for my $ext_file (@ext_files) {
     push @auth_plugins, collect_auth_plugins( $ext->{authPlugin}, $ext_file );
 }
 
+# Warn on conflicting authPlugin declarations (same k with a different v
+# or a different role set across extension files). Dedup below keeps only
+# the first-seen label, so flag the conflict to the maintainer.
+warn_auth_plugin_conflicts( \@auth_plugins );
+
 # Apply auth plugin declarations to the initial merged attributes so the
-# diff-based extraction below also picks up the flat-select additions
-# (authentication, userDB, passwordDB, combModules). authChoiceModules is
-# nested and is always re-applied at call time via @auth_plugins.
+# diff-based extraction below also picks up auth-plugin-driven additions.
+# This initial pass also populates nested authChoiceModules; auth plugins
+# are re-applied again at call time via @auth_plugins on fresh Build.pm
+# data so nested-select changes survive dclone().
 apply_auth_plugins( $attributes, \@auth_plugins );
 
 # 3. Store extension data for merging at call time
@@ -588,6 +594,30 @@ sub apply_auth_plugins {
         # combModules only covers authentication and userDB roles
         if ( $roles{authentication} || $roles{userDB} ) {
             _append_flat_select( $attrs, 'combModules', $opt );
+        }
+    }
+}
+
+sub warn_auth_plugin_conflicts {
+    my ($plugins) = @_;
+    my %seen;
+    for my $p (@$plugins) {
+        my $prev = $seen{ $p->{k} };
+        unless ($prev) {
+            $seen{ $p->{k} } = $p;
+            next;
+        }
+        if ( $prev->{v} ne $p->{v} ) {
+            warn "Warning [$p->{file}]: authPlugin '$p->{k}' label differs "
+              . "from earlier declaration in $prev->{file} "
+              . "('$p->{v}' vs '$prev->{v}'); keeping '$prev->{v}'\n";
+        }
+        my $prev_roles = join ',', sort @{ $prev->{roles} };
+        my $curr_roles = join ',', sort @{ $p->{roles} };
+        if ( $prev_roles ne $curr_roles ) {
+            warn "Warning [$p->{file}]: authPlugin '$p->{k}' roles differ "
+              . "from earlier declaration in $prev->{file} "
+              . "($curr_roles vs $prev_roles); union will be applied\n";
         }
     }
 }

--- a/store/scripts/llng-build-manager-files
+++ b/store/scripts/llng-build-manager-files
@@ -162,11 +162,19 @@ else {
     verbose "No plugins directory specified, running without extensions\n";
 }
 
+my @auth_plugins;
 for my $ext_file (@ext_files) {
     verbose "Loading extension: $ext_file\n";
     my $ext = load_extension($ext_file);
     merge_extension( $attributes, $tree, $ctrees, $constants, $ext, $ext_file );
+    push @auth_plugins, collect_auth_plugins( $ext->{authPlugin}, $ext_file );
 }
+
+# Apply auth plugin declarations to the initial merged attributes so the
+# diff-based extraction below also picks up the flat-select additions
+# (authentication, userDB, passwordDB, combModules). authChoiceModules is
+# nested and is always re-applied at call time via @auth_plugins.
+apply_auth_plugins( $attributes, \@auth_plugins );
 
 # 3. Store extension data for merging at call time
 # Build.pm modifies data in place, so we need fresh copies each time
@@ -279,6 +287,11 @@ my $orig_constants =
                 }
             }
         }
+
+        # Apply authPlugin declarations (fills authentication / userDB /
+        # passwordDB / authChoiceModules / combModules selects based on
+        # declared roles). Safe to re-run: each append is deduplicated.
+        apply_auth_plugins( $fresh, \@auth_plugins );
 
         return $fresh;
     };
@@ -454,6 +467,7 @@ sub load_json_extension {
         ctrees     => $data->{ctrees}     || {},
         constants  => $data->{constants}  || {},
         lang       => $data->{lang}       || {},
+        authPlugin => $data->{authPlugin},
     };
 }
 
@@ -494,9 +508,115 @@ sub load_perl_extension {
     $ext->{constants} =
       defined &{"${pkg}::constants"} ? &{"${pkg}::constants"}() : {};
     $ext->{lang} = defined &{"${pkg}::lang"} ? &{"${pkg}::lang"}() : {};
+    $ext->{authPlugin} =
+      defined &{"${pkg}::authPlugin"} ? &{"${pkg}::authPlugin"}() : undef;
     use strict 'refs';
 
     return $ext;
+}
+
+# Normalize an extension's `authPlugin` entry into a list of
+# { k, v, roles, file } hashes. Accepts a single hash or an array of hashes.
+sub collect_auth_plugins {
+    my ( $raw, $ext_file ) = @_;
+    return () unless $raw;
+
+    my @entries = ref $raw eq 'ARRAY' ? @$raw : ($raw);
+    my @out;
+    for my $entry (@entries) {
+        unless ( ref $entry eq 'HASH' && $entry->{k} && $entry->{v} ) {
+            warn
+"Warning [$ext_file]: authPlugin entries must have 'k' and 'v' keys\n";
+            next;
+        }
+        my $roles =
+            ref $entry->{roles} eq 'ARRAY' ? $entry->{roles}
+          : $entry->{roles}                ? [ $entry->{roles} ]
+          :                                  [];
+        unless (@$roles) {
+            warn
+"Warning [$ext_file]: authPlugin '$entry->{k}' declares no roles\n";
+            next;
+        }
+        my %valid = map { $_ => 1 } qw(authentication userDB passwordDB);
+        my @bad = grep { !$valid{$_} } @$roles;
+        if (@bad) {
+            warn "Warning [$ext_file]: authPlugin '$entry->{k}' has "
+              . "unknown role(s): @bad (allowed: authentication, userDB, passwordDB)\n";
+        }
+        push @out,
+          {
+            k     => $entry->{k},
+            v     => $entry->{v},
+            roles => [ grep { $valid{$_} } @$roles ],
+            file  => $ext_file,
+          };
+    }
+    return @out;
+}
+
+# Mutate $attrs so the given auth plugins appear in the right select lists:
+#   authentication role  -> authentication.select,   authChoiceModules.select[0], combModules.select
+#   userDB         role  -> userDB.select,           authChoiceModules.select[1], combModules.select
+#   passwordDB     role  -> passwordDB.select,       authChoiceModules.select[2]
+# All appends dedupe on the `k` key so re-running is safe.
+sub apply_auth_plugins {
+    my ( $attrs, $plugins ) = @_;
+    return unless $attrs && $plugins && @$plugins;
+
+    my %role_to_flat = (
+        authentication => 'authentication',
+        userDB         => 'userDB',
+        passwordDB     => 'passwordDB',
+    );
+    my %role_to_choice_idx = (
+        authentication => 0,
+        userDB         => 1,
+        passwordDB     => 2,
+    );
+
+    for my $plugin (@$plugins) {
+        my $opt = { k => $plugin->{k}, v => $plugin->{v} };
+        my %roles = map { $_ => 1 } @{ $plugin->{roles} };
+
+        for my $role ( keys %roles ) {
+            _append_flat_select( $attrs, $role_to_flat{$role}, $opt );
+            _append_nested_select( $attrs, 'authChoiceModules',
+                $role_to_choice_idx{$role}, $opt );
+        }
+
+        # combModules only covers authentication and userDB roles
+        if ( $roles{authentication} || $roles{userDB} ) {
+            _append_flat_select( $attrs, 'combModules', $opt );
+        }
+    }
+}
+
+sub _append_flat_select {
+    my ( $attrs, $key, $opt ) = @_;
+    return unless ref $attrs->{$key} eq 'HASH';
+    return unless ref $attrs->{$key}{select} eq 'ARRAY';
+    for my $existing ( @{ $attrs->{$key}{select} } ) {
+        return
+          if ref $existing eq 'HASH'
+          && defined $existing->{k}
+          && $existing->{k} eq $opt->{k};
+    }
+    push @{ $attrs->{$key}{select} }, { %$opt };
+}
+
+sub _append_nested_select {
+    my ( $attrs, $key, $idx, $opt ) = @_;
+    return unless ref $attrs->{$key} eq 'HASH';
+    return unless ref $attrs->{$key}{select} eq 'ARRAY';
+    return unless ref $attrs->{$key}{select}[$idx] eq 'ARRAY';
+    for my $existing ( @{ $attrs->{$key}{select}[$idx] } ) {
+        return
+          if ref $existing eq 'HASH'
+          && defined $existing->{k}
+          && $existing->{k} eq $opt->{k};
+    }
+    push @{ $attrs->{$key}{select}[$idx] }, { %$opt };
 }
 
 sub merge_extension {
@@ -1093,6 +1213,38 @@ Show help message.
       }
     }
   }
+
+=head1 AUTH PLUGIN DECLARATION
+
+Authentication plugins can declare themselves via the C<authPlugin> key
+(top level of an extension file, alongside C<attributes>, C<tree>, etc.)
+instead of manually appending to every select list:
+
+  "authPlugin": {
+    "k": "JsonFile",
+    "v": "JSON File (dev/test)",
+    "roles": ["authentication", "userDB"]
+  }
+
+Multiple plugins may be declared as an array. Allowed roles are
+C<authentication>, C<userDB>, and C<passwordDB>. The option is appended
+to the following core selects based on the declared roles:
+
+=over 4
+
+=item * C<authentication> role: C<authentication>, C<authChoiceModules>
+(auth slot), C<combModules>
+
+=item * C<userDB> role: C<userDB>, C<authChoiceModules> (userDB slot),
+C<combModules>
+
+=item * C<passwordDB> role: C<passwordDB>, C<authChoiceModules>
+(password slot)
+
+=back
+
+Appends are deduplicated on the C<k> key, so re-running the rebuilder
+or declaring the same plugin in multiple files is safe.
 
 =head1 TREE INSERTION
 


### PR DESCRIPTION
## Summary
- New top-level `authPlugin` key in manager-overrides (JSON or Perl) letting auth plugins declare themselves with `k`, `v` and `roles` (subset of `authentication`, `userDB`, `passwordDB`) instead of hand-editing every core select.
- Rebuilder fans the entry out to `authentication` / `userDB` / `passwordDB`, to the right slot of `authChoiceModules` (nested select), and to `combModules` when the plugin targets `authentication` or `userDB`. All appends dedupe on `k` so re-running is safe.
- `json-file` switched to this mechanism, which also fixes its missing entry in `authChoiceModules` (authChoice double-select).

## Test plan
- [ ] Run `llng-build-manager-files` with `plugins/json-file/manager-overrides/json-file.json` and confirm `JsonFile` appears in `authentication`, `userDB`, `authChoiceModules[0]`, `authChoiceModules[1]` and `combModules`, and is absent from `passwordDB` and `authChoiceModules[2]`.
- [ ] Manager UI: create an authChoice entry and verify `JsonFile` is selectable as both auth and userDB.