### PR TITLE
mcp: add local-test MCP server + CLI for plugin testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
     tags-ignore: ['v*']
   pull_request:
 
+env:
+  LLNG_REPO: https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git
+
 jobs:
   discover:
     runs-on: ubuntu-latest
@@ -14,72 +17,116 @@ jobs:
       has_tests: ${{ steps.find.outputs.has_tests }}
     steps:
       - uses: actions/checkout@v5
+
       - id: find
+        name: Build matrix from plugin.json:llng_compat
         run: |
-          plugins='[]'
+          set -euo pipefail
+          REPO="$LLNG_REPO"
+          # Cache of already-checked tags across plugins
+          declare -A TAG_KNOWN
+          tag_exists() {
+            local tag="$1"
+            if [ -z "${TAG_KNOWN[$tag]+x}" ]; then
+              if git ls-remote --tags "$REPO" "$tag" 2>/dev/null \
+                   | grep -Eq "refs/tags/${tag}(\^\{\})?$"; then
+                TAG_KNOWN[$tag]=1
+              else
+                TAG_KNOWN[$tag]=0
+              fi
+            fi
+            [ "${TAG_KNOWN[$tag]}" = "1" ]
+          }
+
+          entries=()
           for d in plugins/*/; do
             [ -d "$d/t" ] || continue
             name=$(basename "$d")
-            plugins=$(echo "$plugins" | jq --arg n "$name" '. + [$n]')
+            compat=$(jq -r '.llng_compat // ""' "$d/plugin.json")
+
+            min=$(echo "$compat" | grep -oE '>=\s*[0-9.]+' \
+                    | grep -oE '[0-9.]+' | head -1 || true)
+            max=$(echo "$compat" | grep -oE '<\s*[0-9.]+' \
+                    | grep -oE '[0-9.]+' | head -1 || true)
+
+            refs=()
+            skip_main=false
+
+            if [ -n "${min:-}" ]; then
+              tag="v$min"
+              if tag_exists "$tag"; then
+                refs+=("$tag")
+                echo "  $name: min tag $tag found"
+              else
+                echo "  $name: min tag $tag not in remote"
+              fi
+            fi
+
+            if [ -n "${max:-}" ]; then
+              tag="v$max"
+              if tag_exists "$tag"; then
+                refs+=("$tag")
+                skip_main=true
+                echo "  $name: max tag $tag found -> skipping main"
+              else
+                echo "  $name: max tag $tag not in remote"
+              fi
+            fi
+
+            if [ "$skip_main" = "false" ]; then
+              refs+=("")  # empty string means "default branch"
+            fi
+
+            for r in "${refs[@]}"; do
+              label="${r:-main}"
+              entries+=("{\"plugin\":\"$name\",\"ref\":\"$r\",\"label\":\"$label\"}")
+            done
           done
-          echo "matrix={\"plugin\":$(echo $plugins)}" >> "$GITHUB_OUTPUT"
-          if [ "$(echo "$plugins" | jq length)" -gt 0 ]; then
-            echo "has_tests=true" >> "$GITHUB_OUTPUT"
-          else
+
+          if [ ${#entries[@]} -eq 0 ]; then
             echo "has_tests=false" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
+
+          include="[$(IFS=,; echo "${entries[*]}")]"
+          echo "has_tests=true" >> "$GITHUB_OUTPUT"
+          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+          echo "Matrix:"
+          echo "$include" | jq .
 
   test:
     needs: discover
     if: needs.discover.outputs.has_tests == 'true'
     runs-on: ubuntu-latest
+    name: ${{ matrix.plugin }} @ ${{ matrix.label }}
     strategy:
       matrix: ${{ fromJson(needs.discover.outputs.matrix) }}
       fail-fast: false
     steps:
-      - name: Checkout plugins
-        uses: actions/checkout@v5
+      - uses: actions/checkout@v5
 
-      - name: Determine LLNG version
-        id: version
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install MCP/CLI dependencies
+        run: cd mcp && npm install --no-audit --no-fund
+
+      - name: Prepare plugin (clone LLNG + make common + symlinks)
         run: |
-          PLUGIN_DIR="plugins/${{ matrix.plugin }}"
-          COMPAT=$(jq -r '.llng_compat // ""' "$PLUGIN_DIR/plugin.json")
-
-          # Parse minimum version from llng_compat
-          # ">=2.23.0" -> "v2.23.0", "<2.23.0" or "" -> HEAD
-          TAG=""
-          if echo "$COMPAT" | grep -qE '^\s*>='; then
-            VER=$(echo "$COMPAT" | sed -E 's/^\s*>=\s*//')
-            TAG="v${VER}"
-          fi
-
-          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "Resolved LLNG version: '${TAG:-HEAD}'"
-
-      - name: Clone LemonLDAP::NG
-        run: |
-          TAG="${{ steps.version.outputs.tag }}"
-          REPO="https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git"
-          if [ -n "$TAG" ]; then
-            # Check if tag exists, fall back to HEAD if not
-            if git ls-remote --tags "$REPO" "$TAG" | grep -q "$TAG"; then
-              echo "Cloning LLNG at tag $TAG"
-              git clone --depth=1 --branch "$TAG" "$REPO" llng
-            else
-              echo "Tag $TAG not found, using HEAD"
-              git clone --depth=1 "$REPO" llng
-            fi
+          REF="${{ matrix.ref }}"
+          if [ -n "$REF" ]; then
+            ./mcp/cli.js prepare "${{ matrix.plugin }}" --ref "$REF"
           else
-            echo "No minimum version, using HEAD"
-            git clone --depth=1 "$REPO" llng
+            ./mcp/cli.js prepare "${{ matrix.plugin }}"
           fi
 
       - name: Install LLNG build dependencies
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends devscripts equivs
-          cd llng
+          cd .llng-test/lemonldap-ng
           sudo mk-build-deps -i -t 'apt-get -y --no-install-recommends' debian/control
 
       - name: Install plugin extra build dependencies
@@ -91,90 +138,5 @@ jobs:
             sudo apt-get install -y --no-install-recommends $BUILD_DEPS
           fi
 
-      - name: Build LemonLDAP::NG
-        run: |
-          cd llng
-          make SKIP_DOCUMENTATION=1
-
-      - name: Place plugin files
-        run: |
-          PLUGIN_DIR="plugins/${{ matrix.plugin }}"
-
-          # Install lib/ and assets from ALL plugins (tests may depend on sibling plugins)
-          for d in plugins/*/; do
-            plugin_name=$(basename "$d")
-
-            # Copy lib/ into lemonldap-ng-portal/blib/lib (overwrite to replace built-in modules)
-            if [ -d "$d/lib" ]; then
-              find "$d/lib" -name '*.pm' | while read src; do
-                rel="${src#$d/lib/}"
-                dst="llng/lemonldap-ng-portal/blib/lib/$rel"
-                mkdir -p "$(dirname "$dst")"
-                if [ -f "$dst" ]; then
-                  echo "$plugin_name: OVERRIDE $rel"
-                else
-                  echo "$plugin_name: COPY $rel"
-                fi
-                cp -f "$src" "$dst"
-              done
-            fi
-
-            # Copy portal-templates/ into site/templates/ (overwrite)
-            if [ -d "$d/portal-templates" ]; then
-              cp -rv "$d/portal-templates/"* llng/lemonldap-ng-portal/site/templates/
-            fi
-
-            # Copy portal-static/ into site/htdocs/static/ (no overwrite)
-            if [ -d "$d/portal-static" ]; then
-              cp -rvn "$d/portal-static/"* llng/lemonldap-ng-portal/site/htdocs/static/
-            fi
-
-            # Merge portal-translations/ into site/htdocs/static/languages/
-            if [ -d "$d/portal-translations" ]; then
-              for tr_file in "$d"/portal-translations/*.json; do
-                [ -f "$tr_file" ] || continue
-                lang="$(basename "$tr_file")"
-                target="llng/lemonldap-ng-portal/site/htdocs/static/languages/$lang"
-                if [ -f "$target" ]; then
-                  jq -s '.[0] * .[1]' "$target" "$tr_file" > "$target.tmp" && mv "$target.tmp" "$target"
-                  echo "$plugin_name: MERGED $lang"
-                else
-                  cp "$tr_file" "$target"
-                fi
-              done
-            fi
-          done
-
-          # Copy test files from the plugin under test into lemonldap-ng-portal/t/
-          cp -v "$PLUGIN_DIR"/t/*.t llng/lemonldap-ng-portal/t/ 2>/dev/null || true
-          cp -v "$PLUGIN_DIR"/t/*.pm llng/lemonldap-ng-portal/t/ 2>/dev/null || true
-          for subdir in "$PLUGIN_DIR"/t/*/; do
-            [ -d "$subdir" ] || continue
-            cp -rv "$subdir" llng/lemonldap-ng-portal/t/
-          done
-
       - name: Run tests
-        run: |
-          PLUGIN_DIR="../../plugins/${{ matrix.plugin }}"
-          cd llng/lemonldap-ng-portal
-
-          # Collect test file names
-          TEST_FILES=""
-          for t in $PLUGIN_DIR/t/*.t; do
-            [ -f "$t" ] || continue
-            TEST_FILES="$TEST_FILES t/$(basename "$t")"
-          done
-
-          if [ -z "$TEST_FILES" ]; then
-            echo "No .t files found"
-            exit 0
-          fi
-
-          echo "Running: prove $TEST_FILES"
-          prove -v \
-            -I../lemonldap-ng-common/blib/lib \
-            -I../lemonldap-ng-handler/blib/lib \
-            -I../lemonldap-ng-manager/blib/lib \
-            -Iblib/lib \
-            -I. \
-            $TEST_FILES
+        run: ./mcp/cli.js execute "${{ matrix.plugin }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .omc
 CLAUDE.md
 .claude/
+.llng-test/
+mcp/node_modules/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "llng-plugins": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["mcp/server.js"]
+    }
+  }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,206 @@
+# Contributing
+
+Thanks for helping improve the LemonLDAP::NG plugins collection! This
+file explains how to set up a local testing environment for a plugin —
+both by hand and via the MCP server shipped with this repo.
+
+Every plugin is a standalone Perl bundle that ships its own `lib/`,
+`t/`, templates and assets. Running its test suite requires grafting
+those files into a live LemonLDAP::NG checkout so that `prove` can see
+them alongside the core modules.
+
+## One-time setup
+
+Install the Node.js tooling once (the MCP server + the standalone CLI
+share the same core and both need this):
+
+```sh
+cd mcp
+npm install
+```
+
+Node.js **18 or later** is required. No system-wide install is
+performed — everything lives under `mcp/node_modules/` (git-ignored).
+
+The first run of any test command will:
+
+1. Shallow-clone LemonLDAP::NG into `.llng-test/lemonldap-ng/`
+   (git-ignored). Override with the `LLNG_REPO_URL` env var if you need
+   a fork or a specific mirror.
+2. Run `make common` inside that checkout (needed because the `Common`
+   component uses autosplit modules that live under `blib/lib/`).
+
+After that, every subsequent prepare reuses the same clone, so only the
+symlinks change between runs.
+
+## Testing without AI — CLI
+
+The CLI `mcp/cli.js` wraps the exact same operations the MCP server
+exposes. Call it directly from anywhere in the repo:
+
+```sh
+./mcp/cli.js list                      # list plugins available under plugins/
+./mcp/cli.js test  ssh-ca              # prepare + prove in one go
+./mcp/cli.js prepare ssh-ca            # just graft the plugin into LLNG
+./mcp/cli.js execute ssh-ca            # just run prove (prepare must have happened)
+./mcp/cli.js execute ssh-ca -- t/01-SSHCA-mycerts.t   # run one specific .t
+./mcp/cli.js clean ssh-ca              # remove that plugin's symlinks + un-merge translations
+./mcp/cli.js clean                     # clean every plugin (keeps the LLNG clone)
+./mcp/cli.js clean-all                 # nuke .llng-test/ entirely
+```
+
+Prepare / test options:
+
+| Flag | Meaning |
+|------|---------|
+| `--skip-make` | Skip `make common` on repeat runs |
+| `--no-deps` | Don't auto-resolve `plugin.json:depends` |
+| `--with a,b,c` | Also link extra plugins (lib + assets only; their tests are not linked) |
+| `--quiet` | Non-verbose `prove` |
+
+If you prefer a shorter name, `npm install` also registers the CLI as
+`llng-plugins-test` — symlink it or add `mcp/node_modules/.bin` to
+your `PATH`.
+
+### What it does, step by step
+
+Running `test ssh-ca` is equivalent to doing this by hand:
+
+```sh
+# 1. Clone LLNG (shallow) — only the first time
+git clone --depth 1 https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git \
+         .llng-test/lemonldap-ng
+cd .llng-test/lemonldap-ng
+
+# 2. Build the Common blib tree
+make common
+
+# 3. Symlink plugin sources into the LLNG tree
+ln -s $PWD/../../plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm \
+      lemonldap-ng-portal/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+# ... same for every .pm, .tpl, .js, .t
+
+# 4. Merge the plugin's language keys into the portal's en.json / fr.json
+#    (additive — core keys are never overwritten)
+
+# 5. Run prove in the correct component dir
+cd lemonldap-ng-portal
+prove -v -I. \
+      -I../lemonldap-ng-common/blib/lib \
+      -I../lemonldap-ng-handler/lib \
+      -I../lemonldap-ng-manager/lib \
+      -I../lemonldap-ng-portal/lib \
+      t/01-SSHCA-mycerts.t t/02-SSHCA-admin.t
+```
+
+The CLI just automates all of this and tracks the merged translation
+keys in `.llng-test/state/<plugin>/translations.json` so that `clean`
+can un-merge them without losing LLNG's core strings.
+
+## Testing with AI — MCP server
+
+The repo ships a `.mcp.json` at its root. If you run an MCP-aware
+client (Claude Code, Cursor, …) from this directory, it auto-discovers
+the `llng-plugins` server and exposes six tools: `list-plugins`,
+`prepare-test`, `execute-test`, `clean-test`, `clean-all`, `test`.
+
+From there you just ask:
+
+> test the ssh-ca plugin
+
+and the agent runs `prepare-test` + `execute-test`, inspects any
+failures, and can iterate.
+
+Don't forget the one-time `cd mcp && npm install` — without it the
+MCP server cannot start.
+
+### Picking between the two
+
+| You're… | Use |
+|---------|-----|
+| writing code in your editor, running tests yourself | the CLI (`./mcp/cli.js …`) |
+| asking an AI agent to fix / extend a plugin | the MCP server |
+| writing a CI pipeline | the CLI (exit codes propagate from `prove`) |
+
+Both talk to the same `lib.js`, so results are identical.
+
+## Plugin layout
+
+The tooling understands the following plugin directory structure:
+
+```
+plugins/<your-plugin>/
+├── plugin.json           # metadata (name, version, depends, …)
+├── lib/
+│   └── Lemonldap/NG/
+│       ├── Common/...     -> linked into lemonldap-ng-common/blib/lib/
+│       ├── Portal/...     -> linked into lemonldap-ng-portal/lib/
+│       ├── Handler/...    -> linked into lemonldap-ng-handler/lib/
+│       └── Manager/...    -> linked into lemonldap-ng-manager/lib/
+├── t/                    # .t files + optional subdirs like t/lib/
+├── portal-templates/      # *.tpl, typically under bootstrap/
+├── portal-static/         # JS/CSS under common/...
+├── manager-static/        # optional, if you extend the manager UI
+├── portal-translations/   # {en,fr,…}.json — additive merge into static/languages/
+├── manager-overrides/     # not linked by the test tooling
+└── README.md
+```
+
+The "primary" component for running tests is chosen by scanning the
+plugin's `.pm` files (priority: `Portal > Handler > Manager > Common`).
+Tests are linked into, and `prove` runs from, that component's
+directory.
+
+## Dependencies between plugins
+
+If your plugin needs another plugin at runtime, list it in
+`plugin.json`:
+
+```json
+{
+  "name": "oidc-device-organization",
+  "depends": ["oidc-device-authorization"],
+  …
+}
+```
+
+Both CLI and MCP walk this transitively: the dependency is grafted
+before the primary plugin. Only the primary's `t/` is linked —
+dependencies contribute runtime code, not test suites.
+
+Use `--with foo,bar` (CLI) or `with: ["foo", "bar"]` (MCP) to add
+plugins that aren't formally declared as dependencies.
+
+## Cleaning up
+
+Cleaning is safe and idempotent:
+
+- `clean <plugin>` — only removes that plugin's symlinks and un-merges
+  its translation keys. Other plugins and the LLNG clone are kept.
+- `clean` — every plugin, clone kept.
+- `clean-all` — deletes `.llng-test/` entirely. Next run re-clones.
+
+Both the clone and any state files live under `.llng-test/`, which is
+in `.gitignore` — nothing from the test environment ever leaks into a
+commit.
+
+## Environment overrides
+
+| Variable | Default |
+|----------|---------|
+| `LLNG_REPO_URL` | `https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git` |
+| `LLNG_PLUGINS_ROOT` | the repo root (parent of `mcp/`) |
+
+Set these if you need to test against a private fork or a
+non-standard layout.
+
+## Writing a new plugin
+
+1. Create `plugins/<your-plugin>/` with the layout above.
+2. Drop your Perl modules into `lib/Lemonldap/NG/<Component>/...`.
+3. Put tests under `t/` — they will be linked into
+   `lemonldap-ng-<primary>/t/`, so `use lib 't/lib';` and similar
+   patterns work out of the box.
+4. `./mcp/cli.js test <your-plugin>` and iterate.
+5. `./mcp/cli.js clean-all` before committing if you want a clean
+   working tree (not strictly required — `.llng-test/` is ignored).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,12 +51,13 @@ exposes. Call it directly from anywhere in the repo:
 
 Prepare / test options:
 
-| Flag | Meaning |
-|------|---------|
-| `--skip-make` | Skip `make common` on repeat runs |
-| `--no-deps` | Don't auto-resolve `plugin.json:depends` |
-| `--with a,b,c` | Also link extra plugins (lib + assets only; their tests are not linked) |
-| `--quiet` | Non-verbose `prove` |
+| Flag           | Meaning                                                                                                                                                              |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--ref <tag>`  | Clone LLNG at a specific git ref (tag or branch). If the ref can't be reached, falls back to the default branch. Changing ref between runs wipes the previous clone. |
+| `--skip-make`  | Skip `make common` on repeat runs                                                                                                                                    |
+| `--no-deps`    | Don't auto-resolve `plugin.json:depends`                                                                                                                             |
+| `--with a,b,c` | Also link extra plugins (lib + assets only; their tests are not linked)                                                                                              |
+| `--quiet`      | Non-verbose `prove`                                                                                                                                                  |
 
 If you prefer a shorter name, `npm install` also registers the CLI as
 `llng-plugins-test` — symlink it or add `mcp/node_modules/.bin` to
@@ -116,11 +117,11 @@ MCP server cannot start.
 
 ### Picking between the two
 
-| You're… | Use |
-|---------|-----|
-| writing code in your editor, running tests yourself | the CLI (`./mcp/cli.js …`) |
-| asking an AI agent to fix / extend a plugin | the MCP server |
-| writing a CI pipeline | the CLI (exit codes propagate from `prove`) |
+| You're…                                             | Use                                         |
+| --------------------------------------------------- | ------------------------------------------- |
+| writing code in your editor, running tests yourself | the CLI (`./mcp/cli.js …`)                  |
+| asking an AI agent to fix / extend a plugin         | the MCP server                              |
+| writing a CI pipeline                               | the CLI (exit codes propagate from `prove`) |
 
 Both talk to the same `lib.js`, so results are identical.
 
@@ -184,12 +185,40 @@ Both the clone and any state files live under `.llng-test/`, which is
 in `.gitignore` — nothing from the test environment ever leaks into a
 commit.
 
+## Continuous integration
+
+The GitHub Actions workflow in `.github/workflows/test.yml` runs on
+top of the very same CLI. For each plugin it reads `plugin.json:llng_compat`
+and builds a test matrix:
+
+| `llng_compat`                              | Refs tested                                                                                           |
+| ------------------------------------------ | ----------------------------------------------------------------------------------------------------- |
+| `>=X.Y.Z` and tag `vX.Y.Z` exists          | **both** `vX.Y.Z` and the LLNG default branch (catches regressions between release and HEAD)          |
+| `>=X.Y.Z` and the tag is not yet published | default branch only                                                                                   |
+| `<X.Y.Z` and tag `vX.Y.Z` exists           | `vX.Y.Z` only — the default branch is **skipped** (plugin declares it doesn't support newer versions) |
+| no `llng_compat`                           | default branch only                                                                                   |
+
+Ranges (`>=A, <B`) are supported — each bound contributes its own tag
+to the matrix, and a satisfied `<` still removes the default branch.
+
+Each matrix job does the same thing a contributor does locally:
+
+```sh
+cd mcp && npm install --no-audit --no-fund
+./mcp/cli.js prepare <plugin> [--ref <tag>]
+# (CI installs LLNG's build deps from debian/control + plugin.build_depends)
+./mcp/cli.js execute <plugin>
+```
+
+Exit code from `prove` propagates all the way up, so a failing test
+fails the job.
+
 ## Environment overrides
 
-| Variable | Default |
-|----------|---------|
-| `LLNG_REPO_URL` | `https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git` |
-| `LLNG_PLUGINS_ROOT` | the repo root (parent of `mcp/`) |
+| Variable            | Default                                                |
+| ------------------- | ------------------------------------------------------ |
+| `LLNG_REPO_URL`     | `https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git` |
+| `LLNG_PLUGINS_ROOT` | the repo root (parent of `mcp/`)                       |
 
 Set these if you need to test against a private fork or a
 non-standard layout.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,0 +1,135 @@
+# LemonLDAP::NG plugins — local-test MCP server
+
+A small [MCP](https://modelcontextprotocol.io/) server that automates the
+plumbing needed to run a plugin's Perl test suite against a real
+LemonLDAP::NG checkout.
+
+It takes care of:
+
+1. **Cloning** LemonLDAP::NG into a hidden, git-ignored directory
+   (`.llng-test/lemonldap-ng/`) on first use (`git clone --depth 1`).
+2. **Building** the `lemonldap-ng-common/blib/lib` tree with `make common`
+   (needed because `Common` ships autosplit modules).
+3. **Symlinking** the plugin's `lib/` files into the correct LLNG component
+   (Portal / Handler / Manager / Common), its `t/` files into that
+   component's `t/` directory, its `portal-templates/`, `portal-static/`
+   and `manager-static/` into the matching site trees.
+4. **Merging** `portal-translations/{en,fr,…}.json` into
+   `lemonldap-ng-portal/site/htdocs/static/languages/` additively
+   (never overwrites a core key; un-merge is tracked per plugin).
+5. **Resolving dependencies**: plugins declared in the primary plugin's
+   `plugin.json:depends` are linked transitively (lib + assets only —
+   their tests are not auto-linked).
+6. **Running** `prove` with the canonical `-I` flag set.
+7. **Cleaning up** symlinks + un-merging translation keys — optionally
+   the whole clone.
+
+## Install
+
+```sh
+cd mcp
+npm install
+```
+
+Node.js 18+ is required. This install is mandatory both for the MCP
+server and for the standalone CLI (`cli.js`): they share the same
+dependencies (`@modelcontextprotocol/sdk`).
+
+## Two entry points
+
+- `server.js` — stdio MCP server (consumed by Claude Code, Cursor, …).
+- `cli.js` — standalone CLI for humans and CI. Same operations, no AI
+  required. Run `./mcp/cli.js --help` or see CONTRIBUTING.md for the
+  full usage.
+
+## Register with Claude Code
+
+The repo ships a `.mcp.json` at its root, so running Claude Code from
+this folder picks up the server automatically. For a global
+registration, add to `~/.claude.json`:
+
+```json
+{
+  "mcpServers": {
+    "llng-plugins": {
+      "command": "node",
+      "args": ["/absolute/path/to/lemonldap-ng-plugins/mcp/server.js"]
+    }
+  }
+}
+```
+
+## Tools
+
+| Tool | What it does |
+|------|--------------|
+| `list-plugins` | Lists every directory under `plugins/`. |
+| `prepare-test` | Clones LLNG if absent, runs `make common`, symlinks lib + t + assets + merges translations. Follows `depends` transitively unless `noDeps:true`. Params: `plugin` (required), `with` (extra plugins), `noDeps`, `skipMake`. |
+| `execute-test` | Runs `prove` in the primary plugin's LLNG component dir. Params: `plugin` (required), `tests` (optional array), `verbose`. |
+| `clean-test` | Removes the plugin's symlinks + un-merges its translation keys. Params: `plugin` or `plugins` to scope; omit both to clean every plugin. The LLNG clone is kept. |
+| `clean-all` | `clean-test` **and** wipes `.llng-test/` entirely. Use to start fresh. |
+| `test` | Convenience: `prepare-test` then `execute-test`. Cleanup is not performed automatically. |
+
+### Plugin → LLNG layout
+
+| Plugin dir | LLNG destination |
+|------------|------------------|
+| `lib/Lemonldap/NG/Common/...` | `lemonldap-ng-common/blib/lib/Lemonldap/NG/Common/...` |
+| `lib/Lemonldap/NG/Portal/...` | `lemonldap-ng-portal/lib/Lemonldap/NG/Portal/...` |
+| `lib/Lemonldap/NG/Handler/...` | `lemonldap-ng-handler/lib/Lemonldap/NG/Handler/...` |
+| `lib/Lemonldap/NG/Manager/...` | `lemonldap-ng-manager/lib/Lemonldap/NG/Manager/...` |
+| `t/` | `lemonldap-ng-<primary>/t/` (including sub-trees like `t/lib/`) |
+| `portal-templates/` | `lemonldap-ng-portal/site/templates/` |
+| `portal-static/` | `lemonldap-ng-portal/site/htdocs/static/` |
+| `manager-static/` | `lemonldap-ng-manager/site/htdocs/static/` |
+| `portal-translations/*.json` | **merged** into `.../static/languages/*.json` (added keys are tracked in `.llng-test/state/<plugin>/translations.json` for un-merge) |
+
+A plugin's primary component is picked by scanning its `.pm` files,
+with priority `Portal > Handler > Manager > Common`. That component's
+directory is where the plugin's tests are linked and where `prove`
+runs.
+
+### The `prove` command
+
+`execute-test` invokes:
+
+```
+prove -v -I. \
+      -I../lemonldap-ng-common/blib/lib \
+      -I../lemonldap-ng-handler/lib \
+      -I../lemonldap-ng-manager/lib \
+      -I../lemonldap-ng-portal/lib \
+      t/...
+```
+
+from inside the primary plugin's component directory (usually
+`.llng-test/lemonldap-ng/lemonldap-ng-portal/`).
+
+### Multi-plugin linking
+
+Example: `oidc-device-organization` declares
+`"depends": ["oidc-device-authorization"]` in its `plugin.json`.
+Running `prepare-test { plugin: "oidc-device-organization" }` links
+both plugins in order (dep first, primary last). Use
+`with: ["other-plugin"]` to add further plugins or
+`noDeps: true` to skip auto-resolution.
+
+Only the **primary** plugin's `t/` is linked. Dependencies contribute
+runtime code (lib + templates + translations), not test suites.
+
+## Environment overrides
+
+| Variable | Default |
+|----------|---------|
+| `LLNG_REPO_URL` | `https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git` |
+| `LLNG_PLUGINS_ROOT` | Parent directory of `mcp/` (this repo's root) |
+
+## Typical workflow
+
+```text
+list-plugins                          -> pick, say, "ssh-ca"
+test   { "plugin": "ssh-ca" }         -> one-shot: prepare + prove
+clean-test { "plugin": "ssh-ca" }     -> remove ssh-ca symlinks + un-merge translations
+# ...iterate on another plugin without re-cloning
+clean-all                             -> full reset (drops the clone too)
+```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -61,28 +61,28 @@ registration, add to `~/.claude.json`:
 
 ## Tools
 
-| Tool | What it does |
-|------|--------------|
-| `list-plugins` | Lists every directory under `plugins/`. |
-| `prepare-test` | Clones LLNG if absent, runs `make common`, symlinks lib + t + assets + merges translations. Follows `depends` transitively unless `noDeps:true`. Params: `plugin` (required), `with` (extra plugins), `noDeps`, `skipMake`. |
-| `execute-test` | Runs `prove` in the primary plugin's LLNG component dir. Params: `plugin` (required), `tests` (optional array), `verbose`. |
-| `clean-test` | Removes the plugin's symlinks + un-merges its translation keys. Params: `plugin` or `plugins` to scope; omit both to clean every plugin. The LLNG clone is kept. |
-| `clean-all` | `clean-test` **and** wipes `.llng-test/` entirely. Use to start fresh. |
-| `test` | Convenience: `prepare-test` then `execute-test`. Cleanup is not performed automatically. |
+| Tool           | What it does                                                                                                                                                                                                                                                                                                                    |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list-plugins` | Lists every directory under `plugins/`.                                                                                                                                                                                                                                                                                         |
+| `prepare-test` | Clones LLNG if absent, runs `make common`, symlinks lib + t + assets + merges translations. Follows `depends` transitively unless `noDeps:true`. Params: `plugin` (required), `with` (extra plugins), `noDeps`, `skipMake`, `ref` (git tag/branch; falls back to default branch if unreachable, wipes the clone on ref change). |
+| `execute-test` | Runs `prove` in the primary plugin's LLNG component dir. Params: `plugin` (required), `tests` (optional array), `verbose`.                                                                                                                                                                                                      |
+| `clean-test`   | Removes the plugin's symlinks + un-merges its translation keys. Params: `plugin` or `plugins` to scope; omit both to clean every plugin. The LLNG clone is kept.                                                                                                                                                                |
+| `clean-all`    | `clean-test` **and** wipes `.llng-test/` entirely. Use to start fresh.                                                                                                                                                                                                                                                          |
+| `test`         | Convenience: `prepare-test` then `execute-test`. Cleanup is not performed automatically.                                                                                                                                                                                                                                        |
 
 ### Plugin → LLNG layout
 
-| Plugin dir | LLNG destination |
-|------------|------------------|
-| `lib/Lemonldap/NG/Common/...` | `lemonldap-ng-common/blib/lib/Lemonldap/NG/Common/...` |
-| `lib/Lemonldap/NG/Portal/...` | `lemonldap-ng-portal/lib/Lemonldap/NG/Portal/...` |
-| `lib/Lemonldap/NG/Handler/...` | `lemonldap-ng-handler/lib/Lemonldap/NG/Handler/...` |
-| `lib/Lemonldap/NG/Manager/...` | `lemonldap-ng-manager/lib/Lemonldap/NG/Manager/...` |
-| `t/` | `lemonldap-ng-<primary>/t/` (including sub-trees like `t/lib/`) |
-| `portal-templates/` | `lemonldap-ng-portal/site/templates/` |
-| `portal-static/` | `lemonldap-ng-portal/site/htdocs/static/` |
-| `manager-static/` | `lemonldap-ng-manager/site/htdocs/static/` |
-| `portal-translations/*.json` | **merged** into `.../static/languages/*.json` (added keys are tracked in `.llng-test/state/<plugin>/translations.json` for un-merge) |
+| Plugin dir                     | LLNG destination                                                                                                                     |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `lib/Lemonldap/NG/Common/...`  | `lemonldap-ng-common/blib/lib/Lemonldap/NG/Common/...`                                                                               |
+| `lib/Lemonldap/NG/Portal/...`  | `lemonldap-ng-portal/lib/Lemonldap/NG/Portal/...`                                                                                    |
+| `lib/Lemonldap/NG/Handler/...` | `lemonldap-ng-handler/lib/Lemonldap/NG/Handler/...`                                                                                  |
+| `lib/Lemonldap/NG/Manager/...` | `lemonldap-ng-manager/lib/Lemonldap/NG/Manager/...`                                                                                  |
+| `t/`                           | `lemonldap-ng-<primary>/t/` (including sub-trees like `t/lib/`)                                                                      |
+| `portal-templates/`            | `lemonldap-ng-portal/site/templates/`                                                                                                |
+| `portal-static/`               | `lemonldap-ng-portal/site/htdocs/static/`                                                                                            |
+| `manager-static/`              | `lemonldap-ng-manager/site/htdocs/static/`                                                                                           |
+| `portal-translations/*.json`   | **merged** into `.../static/languages/*.json` (added keys are tracked in `.llng-test/state/<plugin>/translations.json` for un-merge) |
 
 A plugin's primary component is picked by scanning its `.pm` files,
 with priority `Portal > Handler > Manager > Common`. That component's
@@ -119,10 +119,10 @@ runtime code (lib + templates + translations), not test suites.
 
 ## Environment overrides
 
-| Variable | Default |
-|----------|---------|
-| `LLNG_REPO_URL` | `https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git` |
-| `LLNG_PLUGINS_ROOT` | Parent directory of `mcp/` (this repo's root) |
+| Variable            | Default                                                |
+| ------------------- | ------------------------------------------------------ |
+| `LLNG_REPO_URL`     | `https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git` |
+| `LLNG_PLUGINS_ROOT` | Parent directory of `mcp/` (this repo's root)          |
 
 ## Typical workflow
 

--- a/mcp/cli.js
+++ b/mcp/cli.js
@@ -21,6 +21,9 @@ Commands:
   clean-all                          Remove everything, including the LLNG clone
 
 Options (prepare / test):
+  --ref <ref>        Clone LLNG at this git ref (tag or branch).
+                     If the ref is missing remotely, falls back to the
+                     default branch. Changing ref wipes the previous clone.
   --skip-make        Skip \`make common\` (useful on repeated runs)
   --no-deps          Don't auto-resolve plugin.json "depends"
   --with a,b,c       Also link extra plugins (lib + assets only)
@@ -29,6 +32,7 @@ Options (prepare / test):
 Examples:
   llng-plugins-test list
   llng-plugins-test test ssh-ca
+  llng-plugins-test test ssh-ca --ref v2.23.0
   llng-plugins-test prepare oidc-device-organization --skip-make
   llng-plugins-test execute ssh-ca -- t/01-SSHCA-mycerts.t
   llng-plugins-test clean ssh-ca
@@ -36,7 +40,13 @@ Examples:
 `;
 
 function parseArgs(argv) {
-  const opts = { skipMake: false, noDeps: false, with: [], verbose: true };
+  const opts = {
+    skipMake: false,
+    noDeps: false,
+    with: [],
+    verbose: true,
+    ref: "",
+  };
   const positional = [];
   let afterDashDash = false;
   const extraTests = [];
@@ -54,6 +64,12 @@ function parseArgs(argv) {
       opts.noDeps = true;
     } else if (a === "--quiet") {
       opts.verbose = false;
+    } else if (a === "--ref") {
+      const v = argv[++i];
+      if (v === undefined) throw new Error("--ref requires a value");
+      opts.ref = v;
+    } else if (a.startsWith("--ref=")) {
+      opts.ref = a.slice("--ref=".length);
     } else if (a === "--with") {
       const v = argv[++i];
       if (!v) throw new Error("--with requires a value (comma-separated list)");
@@ -113,10 +129,14 @@ async function main() {
         skipMake: opts.skipMake,
         noDeps: opts.noDeps,
         with: opts.with,
+        ref: opts.ref,
       });
       for (const line of res.log) process.stdout.write(`${line}\n`);
+      const refBadge = res.refFallback
+        ? `${res.ref} (fallback from '${opts.ref}')`
+        : res.ref;
       process.stdout.write(
-        `\nOK — primary=${res.primary} component=${res.component} chain=[${res.chain.join(", ")}] ` +
+        `\nOK — primary=${res.primary} ref=${refBadge} component=${res.component} chain=[${res.chain.join(", ")}] ` +
           `links: lib=${res.totals.lib} tests=${res.totals.tests} assets=${res.totals.assets} translations=${res.totals.translations}\n`,
       );
       return 0;
@@ -151,6 +171,7 @@ async function main() {
         skipMake: opts.skipMake,
         noDeps: opts.noDeps,
         with: opts.with,
+        ref: opts.ref,
       });
       for (const line of prep.log) process.stdout.write(`${line}\n`);
       process.stdout.write("\n");

--- a/mcp/cli.js
+++ b/mcp/cli.js
@@ -1,0 +1,200 @@
+#!/usr/bin/env node
+// Thin CLI around lib.js — lets a human (or a script) run the same
+// operations the MCP server exposes, without any AI/agent involvement.
+
+import {
+  cleanAll,
+  cleanTest,
+  executeTest,
+  listPluginDirs,
+  prepareTest,
+} from "./lib.js";
+
+const USAGE = `Usage: llng-plugins-test <command> [options]
+
+Commands:
+  list                               List plugins available under plugins/
+  prepare <plugin> [options]         Clone LLNG + make common + symlink the plugin
+  execute <plugin> [-- t1 t2 ...]    Run prove on the plugin (prepare must have run)
+  test    <plugin> [options]         prepare + execute in one go
+  clean   [plugin [plugin ...]]      Remove symlinks + un-merge translations (scoped or full)
+  clean-all                          Remove everything, including the LLNG clone
+
+Options (prepare / test):
+  --skip-make        Skip \`make common\` (useful on repeated runs)
+  --no-deps          Don't auto-resolve plugin.json "depends"
+  --with a,b,c       Also link extra plugins (lib + assets only)
+  --quiet            Non-verbose prove (test/execute only)
+
+Examples:
+  llng-plugins-test list
+  llng-plugins-test test ssh-ca
+  llng-plugins-test prepare oidc-device-organization --skip-make
+  llng-plugins-test execute ssh-ca -- t/01-SSHCA-mycerts.t
+  llng-plugins-test clean ssh-ca
+  llng-plugins-test clean-all
+`;
+
+function parseArgs(argv) {
+  const opts = { skipMake: false, noDeps: false, with: [], verbose: true };
+  const positional = [];
+  let afterDashDash = false;
+  const extraTests = [];
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (afterDashDash) {
+      extraTests.push(a);
+      continue;
+    }
+    if (a === "--") {
+      afterDashDash = true;
+    } else if (a === "--skip-make") {
+      opts.skipMake = true;
+    } else if (a === "--no-deps") {
+      opts.noDeps = true;
+    } else if (a === "--quiet") {
+      opts.verbose = false;
+    } else if (a === "--with") {
+      const v = argv[++i];
+      if (!v) throw new Error("--with requires a value (comma-separated list)");
+      opts.with = v.split(",").map((s) => s.trim()).filter(Boolean);
+    } else if (a.startsWith("--with=")) {
+      opts.with = a
+        .slice("--with=".length)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (a === "-h" || a === "--help") {
+      opts.help = true;
+    } else if (a.startsWith("--")) {
+      throw new Error(`Unknown option: ${a}`);
+    } else {
+      positional.push(a);
+    }
+  }
+  return { positional, opts, extraTests };
+}
+
+function fmt(obj) {
+  return JSON.stringify(obj, null, 2);
+}
+
+async function main() {
+  const argv = process.argv.slice(2);
+  if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+
+  const [cmd, ...rest] = argv;
+  let parsed;
+  try {
+    parsed = parseArgs(rest);
+  } catch (e) {
+    process.stderr.write(`${e.message}\n\n${USAGE}`);
+    return 2;
+  }
+  const { positional, opts, extraTests } = parsed;
+
+  switch (cmd) {
+    case "list": {
+      const plugins = await listPluginDirs();
+      for (const p of plugins) process.stdout.write(`${p}\n`);
+      return 0;
+    }
+
+    case "prepare": {
+      const plugin = positional[0];
+      if (!plugin) {
+        process.stderr.write("prepare: missing plugin name\n");
+        return 2;
+      }
+      const res = await prepareTest(plugin, {
+        skipMake: opts.skipMake,
+        noDeps: opts.noDeps,
+        with: opts.with,
+      });
+      for (const line of res.log) process.stdout.write(`${line}\n`);
+      process.stdout.write(
+        `\nOK — primary=${res.primary} component=${res.component} chain=[${res.chain.join(", ")}] ` +
+          `links: lib=${res.totals.lib} tests=${res.totals.tests} assets=${res.totals.assets} translations=${res.totals.translations}\n`,
+      );
+      return 0;
+    }
+
+    case "execute": {
+      const plugin = positional[0];
+      if (!plugin) {
+        process.stderr.write("execute: missing plugin name\n");
+        return 2;
+      }
+      const tests = extraTests.length ? extraTests : positional.slice(1);
+      const res = await executeTest(plugin, {
+        tests: tests.length ? tests : undefined,
+        verbose: opts.verbose,
+        streamStdio: true,
+      });
+      // prove output was streamed live; just report the summary line
+      process.stdout.write(
+        `\n--- prove exit=${res.exitCode} (cwd=${res.cwd})\n`,
+      );
+      return res.exitCode === 0 ? 0 : 1;
+    }
+
+    case "test": {
+      const plugin = positional[0];
+      if (!plugin) {
+        process.stderr.write("test: missing plugin name\n");
+        return 2;
+      }
+      const prep = await prepareTest(plugin, {
+        skipMake: opts.skipMake,
+        noDeps: opts.noDeps,
+        with: opts.with,
+      });
+      for (const line of prep.log) process.stdout.write(`${line}\n`);
+      process.stdout.write("\n");
+      const tests = extraTests.length ? extraTests : positional.slice(1);
+      const res = await executeTest(plugin, {
+        tests: tests.length ? tests : undefined,
+        verbose: opts.verbose,
+        streamStdio: true,
+      });
+      process.stdout.write(`\n--- prove exit=${res.exitCode}\n`);
+      return res.exitCode === 0 ? 0 : 1;
+    }
+
+    case "clean": {
+      const scope = positional.length ? positional : undefined;
+      const res = await cleanTest({ plugins: scope });
+      process.stdout.write(fmt({
+        removedCount: res.removed.length,
+        translationKeysRemoved: res.unmerged,
+      }) + "\n");
+      return 0;
+    }
+
+    case "clean-all": {
+      const res = await cleanAll();
+      process.stdout.write(fmt({
+        removedCount: res.removed.length,
+        translationKeysRemoved: res.unmerged,
+        clonedRemoved: res.clonedRemoved,
+        llngRoot: res.llngRoot,
+      }) + "\n");
+      return 0;
+    }
+
+    default:
+      process.stderr.write(`Unknown command: ${cmd}\n\n${USAGE}`);
+      return 2;
+  }
+}
+
+main().then(
+  (code) => process.exit(code ?? 0),
+  (err) => {
+    process.stderr.write(`${err.stack || err.message || err}\n`);
+    process.exit(1);
+  },
+);

--- a/mcp/cli.js
+++ b/mcp/cli.js
@@ -95,6 +95,16 @@ function fmt(obj) {
   return JSON.stringify(obj, null, 2);
 }
 
+// Forward the child process exit code, clamped to the 0-255 range
+// required by POSIX exit status.
+function clampExit(code) {
+  if (code === 0) return 0;
+  if (typeof code !== "number" || Number.isNaN(code)) return 1;
+  const c = Math.trunc(code);
+  if (c < 0) return 1;
+  return c > 255 ? 255 : c;
+}
+
 async function main() {
   const argv = process.argv.slice(2);
   if (argv.length === 0 || argv[0] === "-h" || argv[0] === "--help") {
@@ -111,6 +121,11 @@ async function main() {
     return 2;
   }
   const { positional, opts, extraTests } = parsed;
+
+  if (opts.help) {
+    process.stdout.write(USAGE);
+    return 0;
+  }
 
   switch (cmd) {
     case "list": {
@@ -158,7 +173,7 @@ async function main() {
       process.stdout.write(
         `\n--- prove exit=${res.exitCode} (cwd=${res.cwd})\n`,
       );
-      return res.exitCode === 0 ? 0 : 1;
+      return clampExit(res.exitCode);
     }
 
     case "test": {
@@ -182,7 +197,7 @@ async function main() {
         streamStdio: true,
       });
       process.stdout.write(`\n--- prove exit=${res.exitCode}\n`);
-      return res.exitCode === 0 ? 0 : 1;
+      return clampExit(res.exitCode);
     }
 
     case "clean": {

--- a/mcp/lib.js
+++ b/mcp/lib.js
@@ -154,22 +154,82 @@ async function resolveDependencies(root, opts = {}) {
   return order;
 }
 
-async function ensureLlng(log) {
-  if (await exists(path.join(LLNG_DIR, ".git"))) {
-    log.push(`LLNG clone already present at ${LLNG_DIR}`);
-    return;
+const META_FILE = path.join(STATE_DIR, "_meta.json");
+
+async function readMeta() {
+  if (!(await exists(META_FILE))) return {};
+  try {
+    return JSON.parse(await fs.readFile(META_FILE, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+async function writeMeta(meta) {
+  await fs.mkdir(STATE_DIR, { recursive: true });
+  await fs.writeFile(META_FILE, JSON.stringify(meta, null, 2) + "\n");
+}
+
+async function ensureLlng(log, { ref } = {}) {
+  const wantedRef = ref || "";
+  const gitDir = path.join(LLNG_DIR, ".git");
+  const meta = await readMeta();
+  const currentRef = meta.ref ?? null;
+
+  if ((await exists(gitDir)) && currentRef === wantedRef) {
+    log.push(
+      `LLNG clone already present at ${LLNG_DIR} (ref: ${currentRef || "default"})`,
+    );
+    return { ref: currentRef, fallback: false };
+  }
+
+  if (await exists(LLNG_ROOT)) {
+    log.push(
+      `Ref change (${currentRef ?? "<none>"} -> ${wantedRef || "default"}); wiping previous clone`,
+    );
+    await fs.rm(LLNG_ROOT, { recursive: true, force: true });
   }
   await fs.mkdir(LLNG_ROOT, { recursive: true });
-  log.push(`Cloning ${LLNG_REPO} (shallow) into ${LLNG_DIR} ...`);
-  const r = await run("git", ["clone", "--depth", "1", LLNG_REPO, LLNG_DIR], {
-    cwd: LLNG_ROOT,
-  });
-  if (r.code !== 0) {
-    throw new Error(
-      `git clone failed (exit ${r.code}):\n${r.stderr || r.stdout}`,
+
+  let actualRef = wantedRef;
+  let fallback = false;
+
+  if (wantedRef) {
+    log.push(`Cloning ${LLNG_REPO} at ref '${wantedRef}' (shallow) ...`);
+    const r = await run(
+      "git",
+      ["clone", "--depth", "1", "--branch", wantedRef, LLNG_REPO, LLNG_DIR],
+      { cwd: LLNG_ROOT },
     );
+    if (r.code !== 0) {
+      log.push(
+        `  ref '${wantedRef}' not reachable — falling back to default branch`,
+      );
+      await fs.rm(LLNG_DIR, { recursive: true, force: true });
+      actualRef = "";
+      fallback = true;
+    }
   }
-  log.push("Clone OK");
+
+  if (!actualRef && !(await exists(gitDir))) {
+    log.push(`Cloning ${LLNG_REPO} (default branch, shallow) ...`);
+    const r = await run(
+      "git",
+      ["clone", "--depth", "1", LLNG_REPO, LLNG_DIR],
+      { cwd: LLNG_ROOT },
+    );
+    if (r.code !== 0) {
+      throw new Error(
+        `git clone failed (exit ${r.code}):\n${r.stderr || r.stdout}`,
+      );
+    }
+  }
+
+  await writeMeta({ ref: actualRef });
+  log.push(
+    `Clone OK (ref: ${actualRef || "default"}${fallback ? " — fallback from " + wantedRef : ""})`,
+  );
+  return { ref: actualRef, fallback };
 }
 
 async function makeCommon(log) {
@@ -336,11 +396,11 @@ async function unmergeTranslations(pluginName) {
 
 export async function prepareTest(
   primary,
-  { skipMake = false, with: extra = [], noDeps = false } = {},
+  { skipMake = false, with: extra = [], noDeps = false, ref = "" } = {},
 ) {
   const log = [];
   const chain = await resolveDependencies(primary, { noDeps, extra });
-  await ensureLlng(log);
+  const cloneInfo = await ensureLlng(log, { ref });
   if (!skipMake) await makeCommon(log);
 
   const primaryComponent = await detectPrimaryComponent(
@@ -361,7 +421,15 @@ export async function prepareTest(
     }
   }
 
-  return { primary, chain, component: primaryComponent, totals, log };
+  return {
+    primary,
+    chain,
+    component: primaryComponent,
+    ref: cloneInfo.ref || "default",
+    refFallback: cloneInfo.fallback,
+    totals,
+    log,
+  };
 }
 
 export async function executeTest(

--- a/mcp/lib.js
+++ b/mcp/lib.js
@@ -1,0 +1,490 @@
+// Core operations shared by the MCP server (server.js) and the CLI (cli.js).
+
+import { spawn } from "node:child_process";
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+export const PROJECT_ROOT =
+  process.env.LLNG_PLUGINS_ROOT || path.resolve(__dirname, "..");
+export const PLUGINS_DIR = path.join(PROJECT_ROOT, "plugins");
+export const LLNG_ROOT = path.join(PROJECT_ROOT, ".llng-test");
+export const LLNG_DIR = path.join(LLNG_ROOT, "lemonldap-ng");
+export const STATE_DIR = path.join(LLNG_ROOT, "state");
+export const LLNG_REPO =
+  process.env.LLNG_REPO_URL ||
+  "https://gitlab.ow2.org/lemonldap-ng/lemonldap-ng.git";
+
+const COMPONENT_MAP = {
+  Common: { dir: "lemonldap-ng-common", libPath: "blib/lib" },
+  Portal: { dir: "lemonldap-ng-portal", libPath: "lib" },
+  Handler: { dir: "lemonldap-ng-handler", libPath: "lib" },
+  Manager: { dir: "lemonldap-ng-manager", libPath: "lib" },
+};
+const COMPONENT_PRIORITY = ["Portal", "Handler", "Manager", "Common"];
+
+const ASSET_TREES = [
+  { src: "portal-templates", dst: ["lemonldap-ng-portal", "site", "templates"] },
+  { src: "portal-static", dst: ["lemonldap-ng-portal", "site", "htdocs", "static"] },
+  { src: "manager-static", dst: ["lemonldap-ng-manager", "site", "htdocs", "static"] },
+];
+
+const TRANSLATIONS_DIR = [
+  "lemonldap-ng-portal",
+  "site",
+  "htdocs",
+  "static",
+  "languages",
+];
+
+function run(cmd, args, opts = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(cmd, args, {
+      stdio: ["ignore", "pipe", "pipe"],
+      ...opts,
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (d) => (stdout += d.toString()));
+    child.stderr.on("data", (d) => (stderr += d.toString()));
+    if (opts.streamStdout) child.stdout.on("data", (d) => process.stdout.write(d));
+    if (opts.streamStderr) child.stderr.on("data", (d) => process.stderr.write(d));
+    child.on("close", (code) => resolve({ code: code ?? -1, stdout, stderr }));
+    child.on("error", (err) =>
+      resolve({ code: -1, stdout, stderr: stderr + String(err) }),
+    );
+  });
+}
+
+async function exists(p) {
+  try {
+    await fs.access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function listPluginDirs() {
+  const entries = await fs.readdir(PLUGINS_DIR, { withFileTypes: true });
+  return entries
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .sort();
+}
+
+async function walkFiles(dir, filter = () => true) {
+  const out = [];
+  async function walk(current) {
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = path.join(current, e.name);
+      if (e.isDirectory()) await walk(p);
+      else if (e.isFile() && filter(p, e)) out.push(p);
+    }
+  }
+  await walk(dir);
+  return out;
+}
+
+function analyzePmPath(libRoot, pmFile) {
+  const rel = path.relative(libRoot, pmFile);
+  const parts = rel.split(path.sep);
+  if (
+    parts.length < 4 ||
+    parts[0] !== "Lemonldap" ||
+    parts[1] !== "NG" ||
+    !COMPONENT_MAP[parts[2]]
+  ) {
+    return null;
+  }
+  return { topLevel: parts[2], subPath: parts.slice(2).join(path.sep) };
+}
+
+async function detectPrimaryComponent(pluginDir) {
+  const libRoot = path.join(pluginDir, "lib");
+  if (!(await exists(libRoot))) return "Portal";
+  const pms = await walkFiles(libRoot, (p) => p.endsWith(".pm"));
+  const seen = new Set();
+  for (const pm of pms) {
+    const info = analyzePmPath(libRoot, pm);
+    if (info) seen.add(info.topLevel);
+  }
+  for (const c of COMPONENT_PRIORITY) if (seen.has(c)) return c;
+  return "Portal";
+}
+
+async function readPluginJson(pluginName) {
+  const p = path.join(PLUGINS_DIR, pluginName, "plugin.json");
+  if (!(await exists(p))) return null;
+  try {
+    return JSON.parse(await fs.readFile(p, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function resolveDependencies(root, opts = {}) {
+  const { noDeps = false, extra = [] } = opts;
+  const visited = new Set();
+  const order = [];
+  async function visit(name) {
+    if (visited.has(name)) return;
+    visited.add(name);
+    if (!(await exists(path.join(PLUGINS_DIR, name)))) {
+      throw new Error(`Plugin not found: ${name}`);
+    }
+    if (!noDeps) {
+      const meta = await readPluginJson(name);
+      const deps = Array.isArray(meta?.depends) ? meta.depends : [];
+      for (const d of deps) await visit(d);
+    }
+    order.push(name);
+  }
+  for (const e of extra) await visit(e);
+  await visit(root);
+  return order;
+}
+
+async function ensureLlng(log) {
+  if (await exists(path.join(LLNG_DIR, ".git"))) {
+    log.push(`LLNG clone already present at ${LLNG_DIR}`);
+    return;
+  }
+  await fs.mkdir(LLNG_ROOT, { recursive: true });
+  log.push(`Cloning ${LLNG_REPO} (shallow) into ${LLNG_DIR} ...`);
+  const r = await run("git", ["clone", "--depth", "1", LLNG_REPO, LLNG_DIR], {
+    cwd: LLNG_ROOT,
+  });
+  if (r.code !== 0) {
+    throw new Error(
+      `git clone failed (exit ${r.code}):\n${r.stderr || r.stdout}`,
+    );
+  }
+  log.push("Clone OK");
+}
+
+async function makeCommon(log) {
+  log.push("Running `make common` ...");
+  const r = await run("make", ["common"], { cwd: LLNG_DIR });
+  if (r.code !== 0) {
+    throw new Error(
+      `make common failed (exit ${r.code}):\n${r.stderr || r.stdout}`,
+    );
+  }
+  log.push("`make common` OK");
+}
+
+async function forceSymlink(source, target) {
+  try {
+    const st = await fs.lstat(target);
+    if (st.isSymbolicLink() || st.isFile()) await fs.unlink(target);
+    else if (st.isDirectory()) await fs.rm(target, { recursive: true, force: true });
+  } catch {
+    // no prior entry
+  }
+  await fs.symlink(source, target);
+}
+
+async function linkPluginLib(pluginName, log) {
+  const libRoot = path.join(PLUGINS_DIR, pluginName, "lib");
+  if (!(await exists(libRoot))) return 0;
+  const pms = await walkFiles(libRoot, (p) => p.endsWith(".pm"));
+  let n = 0;
+  for (const pm of pms) {
+    const info = analyzePmPath(libRoot, pm);
+    if (!info) continue;
+    const { dir, libPath } = COMPONENT_MAP[info.topLevel];
+    const target = path.join(LLNG_DIR, dir, libPath, "Lemonldap", "NG", info.subPath);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await forceSymlink(pm, target);
+    log.push(`  lib: ${path.relative(LLNG_DIR, target)}`);
+    n++;
+  }
+  return n;
+}
+
+async function linkPluginTests(pluginName, component, log) {
+  const tRoot = path.join(PLUGINS_DIR, pluginName, "t");
+  if (!(await exists(tRoot))) return 0;
+  const { dir } = COMPONENT_MAP[component];
+  const testDir = path.join(LLNG_DIR, dir, "t");
+  await fs.mkdir(testDir, { recursive: true });
+  const files = await walkFiles(tRoot);
+  let n = 0;
+  for (const f of files) {
+    const rel = path.relative(tRoot, f);
+    const target = path.join(testDir, rel);
+    await fs.mkdir(path.dirname(target), { recursive: true });
+    await forceSymlink(f, target);
+    log.push(`  t:   ${path.relative(LLNG_DIR, target)}`);
+    n++;
+  }
+  return n;
+}
+
+async function linkPluginAssets(pluginName, log) {
+  let n = 0;
+  for (const { src, dst } of ASSET_TREES) {
+    const srcRoot = path.join(PLUGINS_DIR, pluginName, src);
+    if (!(await exists(srcRoot))) continue;
+    const dstRoot = path.join(LLNG_DIR, ...dst);
+    if (!(await exists(dstRoot))) {
+      log.push(`  skip ${src}: ${path.relative(LLNG_DIR, dstRoot)} missing`);
+      continue;
+    }
+    const files = await walkFiles(srcRoot);
+    for (const f of files) {
+      const rel = path.relative(srcRoot, f);
+      const target = path.join(dstRoot, rel);
+      await fs.mkdir(path.dirname(target), { recursive: true });
+      await forceSymlink(f, target);
+      log.push(`  ${src}: ${path.relative(LLNG_DIR, target)}`);
+      n++;
+    }
+  }
+  return n;
+}
+
+function serializeTranslations(obj) {
+  const keys = Object.keys(obj);
+  const lines = keys.map((k, i) => {
+    const sep = i < keys.length - 1 ? "," : "";
+    return `${JSON.stringify(k)}:${JSON.stringify(obj[k])}${sep}`;
+  });
+  return `{\n${lines.join("\n")}\n}\n`;
+}
+
+async function mergeTranslations(pluginName, log) {
+  const srcDir = path.join(PLUGINS_DIR, pluginName, "portal-translations");
+  if (!(await exists(srcDir))) return 0;
+  const dstDir = path.join(LLNG_DIR, ...TRANSLATIONS_DIR);
+  if (!(await exists(dstDir))) {
+    log.push(`  skip portal-translations: ${dstDir} missing`);
+    return 0;
+  }
+
+  const stateDir = path.join(STATE_DIR, pluginName);
+  await fs.mkdir(stateDir, { recursive: true });
+  const stateFile = path.join(stateDir, "translations.json");
+  let state = { files: {} };
+  if (await exists(stateFile)) {
+    try {
+      state = JSON.parse(await fs.readFile(stateFile, "utf8"));
+      if (!state.files) state.files = {};
+    } catch {
+      state = { files: {} };
+    }
+  }
+
+  const files = (await fs.readdir(srcDir)).filter((f) => f.endsWith(".json"));
+  let total = 0;
+  for (const f of files) {
+    const srcJson = JSON.parse(await fs.readFile(path.join(srcDir, f), "utf8"));
+    const dstPath = path.join(dstDir, f);
+    let dstJson = {};
+    if (await exists(dstPath)) {
+      dstJson = JSON.parse(await fs.readFile(dstPath, "utf8"));
+    }
+    const known = new Set(state.files[f] || []);
+    for (const [k, v] of Object.entries(srcJson)) {
+      if (!(k in dstJson)) {
+        dstJson[k] = v;
+        known.add(k);
+        total++;
+      } else if (known.has(k)) {
+        dstJson[k] = v;
+      }
+    }
+    state.files[f] = [...known];
+    await fs.writeFile(dstPath, serializeTranslations(dstJson));
+    log.push(`  tr:  merged ${known.size} key(s) into ${f}`);
+  }
+  await fs.writeFile(stateFile, JSON.stringify(state, null, 2));
+  return total;
+}
+
+async function unmergeTranslations(pluginName) {
+  const stateFile = path.join(STATE_DIR, pluginName, "translations.json");
+  if (!(await exists(stateFile))) return 0;
+  const state = JSON.parse(await fs.readFile(stateFile, "utf8"));
+  const dstDir = path.join(LLNG_DIR, ...TRANSLATIONS_DIR);
+  let removed = 0;
+  for (const [f, keys] of Object.entries(state.files || {})) {
+    const dstPath = path.join(dstDir, f);
+    if (!(await exists(dstPath))) continue;
+    const json = JSON.parse(await fs.readFile(dstPath, "utf8"));
+    for (const k of keys) {
+      if (k in json) {
+        delete json[k];
+        removed++;
+      }
+    }
+    await fs.writeFile(dstPath, serializeTranslations(json));
+  }
+  await fs.rm(path.dirname(stateFile), { recursive: true, force: true });
+  return removed;
+}
+
+export async function prepareTest(
+  primary,
+  { skipMake = false, with: extra = [], noDeps = false } = {},
+) {
+  const log = [];
+  const chain = await resolveDependencies(primary, { noDeps, extra });
+  await ensureLlng(log);
+  if (!skipMake) await makeCommon(log);
+
+  const primaryComponent = await detectPrimaryComponent(
+    path.join(PLUGINS_DIR, primary),
+  );
+  log.push(
+    `Plugins to link (in order): ${chain.join(", ")} — primary component: ${primaryComponent}`,
+  );
+
+  const totals = { lib: 0, tests: 0, assets: 0, translations: 0 };
+  for (const name of chain) {
+    log.push(`--- ${name} ---`);
+    totals.lib += await linkPluginLib(name, log);
+    totals.assets += await linkPluginAssets(name, log);
+    totals.translations += await mergeTranslations(name, log);
+    if (name === primary) {
+      totals.tests += await linkPluginTests(name, primaryComponent, log);
+    }
+  }
+
+  return { primary, chain, component: primaryComponent, totals, log };
+}
+
+export async function executeTest(
+  primary,
+  { tests, verbose = true, streamStdio = false } = {},
+) {
+  const component = await detectPrimaryComponent(
+    path.join(PLUGINS_DIR, primary),
+  );
+  const { dir } = COMPONENT_MAP[component];
+  const runDir = path.join(LLNG_DIR, dir);
+  if (!(await exists(runDir))) {
+    throw new Error(
+      `LLNG component dir missing: ${runDir} — run prepare-test first`,
+    );
+  }
+
+  const args = [];
+  if (verbose) args.push("-v");
+  args.push(
+    "-I.",
+    "-I../lemonldap-ng-common/blib/lib",
+    "-I../lemonldap-ng-handler/lib",
+    "-I../lemonldap-ng-manager/lib",
+    "-I../lemonldap-ng-portal/lib",
+  );
+
+  const pluginTestDir = path.join(PLUGINS_DIR, primary, "t");
+  let targets;
+  if (tests && tests.length) {
+    targets = tests.map((t) => (path.isAbsolute(t) ? t : path.join("t", t)));
+  } else if (await exists(pluginTestDir)) {
+    const files = await walkFiles(pluginTestDir, (p) => p.endsWith(".t"));
+    targets = files
+      .map((f) => path.join("t", path.relative(pluginTestDir, f)))
+      .sort();
+    if (targets.length === 0) {
+      throw new Error(`No .t files found under ${pluginTestDir}`);
+    }
+  } else {
+    throw new Error(`Plugin ${primary} has no t/ directory`);
+  }
+  args.push(...targets);
+
+  const r = await run("prove", args, {
+    cwd: runDir,
+    streamStdout: streamStdio,
+    streamStderr: streamStdio,
+  });
+  return {
+    plugin: primary,
+    component,
+    cwd: runDir,
+    command: `prove ${args.join(" ")}`,
+    exitCode: r.code,
+    stdout: r.stdout,
+    stderr: r.stderr,
+  };
+}
+
+async function removeSymlinksUnder(targetPrefix, removed) {
+  async function walk(current) {
+    let entries;
+    try {
+      entries = await fs.readdir(current, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = path.join(current, e.name);
+      if (e.isSymbolicLink()) {
+        try {
+          const link = await fs.readlink(p);
+          const resolved = path.resolve(current, link);
+          if (
+            resolved === targetPrefix.slice(0, -1) ||
+            resolved.startsWith(targetPrefix)
+          ) {
+            await fs.unlink(p);
+            removed.push(p);
+          }
+        } catch {
+          /* broken link */
+        }
+      } else if (e.isDirectory()) {
+        await walk(p);
+      }
+    }
+  }
+  await walk(LLNG_DIR);
+}
+
+async function listPluginsWithState() {
+  if (!(await exists(STATE_DIR))) return [];
+  const entries = await fs.readdir(STATE_DIR, { withFileTypes: true });
+  return entries.filter((e) => e.isDirectory()).map((e) => e.name);
+}
+
+export async function cleanTest({ plugins } = {}) {
+  if (!(await exists(LLNG_DIR))) return { removed: [], unmerged: 0 };
+  const scope = plugins && plugins.length ? plugins : null;
+  const removed = [];
+  if (scope) {
+    for (const p of scope) {
+      await removeSymlinksUnder(path.join(PLUGINS_DIR, p) + path.sep, removed);
+    }
+  } else {
+    await removeSymlinksUnder(PLUGINS_DIR + path.sep, removed);
+  }
+  let unmerged = 0;
+  const targets = scope || (await listPluginsWithState());
+  for (const p of targets) {
+    unmerged += await unmergeTranslations(p);
+  }
+  return { removed, unmerged };
+}
+
+export async function cleanAll() {
+  const pre = await cleanTest();
+  let clonedRemoved = false;
+  if (await exists(LLNG_ROOT)) {
+    await fs.rm(LLNG_ROOT, { recursive: true, force: true });
+    clonedRemoved = true;
+  }
+  return { ...pre, clonedRemoved, llngRoot: LLNG_ROOT };
+}

--- a/mcp/lib.js
+++ b/mcp/lib.js
@@ -122,7 +122,31 @@ async function detectPrimaryComponent(pluginDir) {
   return "Portal";
 }
 
+function validatePluginName(name) {
+  if (typeof name !== "string" || !name) {
+    throw new Error(`invalid plugin name: ${JSON.stringify(name)}`);
+  }
+  if (
+    name === "." ||
+    name === ".." ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.includes("\0") ||
+    path.isAbsolute(name)
+  ) {
+    throw new Error(`invalid plugin name (path separators not allowed): ${name}`);
+  }
+  const resolved = path.resolve(PLUGINS_DIR, name);
+  if (
+    resolved !== path.join(PLUGINS_DIR, name) ||
+    !resolved.startsWith(PLUGINS_DIR + path.sep)
+  ) {
+    throw new Error(`invalid plugin name (escapes plugins/): ${name}`);
+  }
+}
+
 async function readPluginJson(pluginName) {
+  validatePluginName(pluginName);
   const p = path.join(PLUGINS_DIR, pluginName, "plugin.json");
   if (!(await exists(p))) return null;
   try {
@@ -137,6 +161,7 @@ async function resolveDependencies(root, opts = {}) {
   const visited = new Set();
   const order = [];
   async function visit(name) {
+    validatePluginName(name);
     if (visited.has(name)) return;
     visited.add(name);
     if (!(await exists(path.join(PLUGINS_DIR, name)))) {
@@ -354,19 +379,41 @@ async function mergeTranslations(pluginName, log) {
     if (await exists(dstPath)) {
       dstJson = JSON.parse(await fs.readFile(dstPath, "utf8"));
     }
-    const known = new Set(state.files[f] || []);
+    // Known keys are tracked as { key -> value-we-last-wrote }. This lets
+    // un-merge distinguish "still our key" (current value matches what we
+    // wrote) from "upstream took over" (value changed meanwhile). Legacy
+    // array form is migrated silently.
+    const prev = state.files[f];
+    const known = {};
+    if (Array.isArray(prev)) {
+      for (const k of prev) if (k in dstJson) known[k] = dstJson[k];
+    } else if (prev && typeof prev === "object") {
+      Object.assign(known, prev);
+    }
+
     for (const [k, v] of Object.entries(srcJson)) {
       if (!(k in dstJson)) {
         dstJson[k] = v;
-        known.add(k);
+        known[k] = v;
         total++;
-      } else if (known.has(k)) {
+      } else if (
+        Object.prototype.hasOwnProperty.call(known, k) &&
+        dstJson[k] === known[k]
+      ) {
+        // Still our key (nobody touched it since we wrote it) — refresh.
         dstJson[k] = v;
+        known[k] = v;
+      } else if (Object.prototype.hasOwnProperty.call(known, k)) {
+        // We added it before, but dstJson no longer matches — upstream or
+        // another plugin owns this key now. Relinquish ownership so future
+        // un-merge won't clobber their value.
+        delete known[k];
       }
+      // else: pre-existing core key we never touched — leave it alone.
     }
-    state.files[f] = [...known];
+    state.files[f] = known;
     await fs.writeFile(dstPath, serializeTranslations(dstJson));
-    log.push(`  tr:  merged ${known.size} key(s) into ${f}`);
+    log.push(`  tr:  merged ${Object.keys(known).length} key(s) into ${f}`);
   }
   await fs.writeFile(stateFile, JSON.stringify(state, null, 2));
   return total;
@@ -378,14 +425,27 @@ async function unmergeTranslations(pluginName) {
   const state = JSON.parse(await fs.readFile(stateFile, "utf8"));
   const dstDir = path.join(LLNG_DIR, ...TRANSLATIONS_DIR);
   let removed = 0;
-  for (const [f, keys] of Object.entries(state.files || {})) {
+  for (const [f, entry] of Object.entries(state.files || {})) {
     const dstPath = path.join(dstDir, f);
     if (!(await exists(dstPath))) continue;
     const json = JSON.parse(await fs.readFile(dstPath, "utf8"));
-    for (const k of keys) {
-      if (k in json) {
-        delete json[k];
-        removed++;
+    // Legacy state (array of keys) → blind removal, pre-existing behaviour.
+    // New state (object key→value) → only remove when the current value
+    // still matches what we wrote, otherwise upstream / another plugin now
+    // owns the key and we must not touch it.
+    if (Array.isArray(entry)) {
+      for (const k of entry) {
+        if (k in json) {
+          delete json[k];
+          removed++;
+        }
+      }
+    } else if (entry && typeof entry === "object") {
+      for (const [k, storedValue] of Object.entries(entry)) {
+        if (k in json && json[k] === storedValue) {
+          delete json[k];
+          removed++;
+        }
       }
     }
     await fs.writeFile(dstPath, serializeTranslations(json));
@@ -398,6 +458,8 @@ export async function prepareTest(
   primary,
   { skipMake = false, with: extra = [], noDeps = false, ref = "" } = {},
 ) {
+  validatePluginName(primary);
+  for (const e of extra) validatePluginName(e);
   const log = [];
   const chain = await resolveDependencies(primary, { noDeps, extra });
   const cloneInfo = await ensureLlng(log, { ref });
@@ -436,6 +498,7 @@ export async function executeTest(
   primary,
   { tests, verbose = true, streamStdio = false } = {},
 ) {
+  validatePluginName(primary);
   const component = await detectPrimaryComponent(
     path.join(PLUGINS_DIR, primary),
   );
@@ -460,7 +523,13 @@ export async function executeTest(
   const pluginTestDir = path.join(PLUGINS_DIR, primary, "t");
   let targets;
   if (tests && tests.length) {
-    targets = tests.map((t) => (path.isAbsolute(t) ? t : path.join("t", t)));
+    targets = tests.map((t) => {
+      if (path.isAbsolute(t)) return t;
+      if (t === "t" || t.startsWith("t/") || t.startsWith(`t${path.sep}`)) {
+        return t;
+      }
+      return path.join("t", t);
+    });
   } else if (await exists(pluginTestDir)) {
     const files = await walkFiles(pluginTestDir, (p) => p.endsWith(".t"));
     targets = files
@@ -530,6 +599,9 @@ async function listPluginsWithState() {
 
 export async function cleanTest({ plugins } = {}) {
   if (!(await exists(LLNG_DIR))) return { removed: [], unmerged: 0 };
+  if (plugins && plugins.length) {
+    for (const p of plugins) validatePluginName(p);
+  }
   const scope = plugins && plugins.length ? plugins : null;
   const removed = [];
   if (scope) {

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,0 +1,1145 @@
+{
+  "name": "@linagora/lemonldap-ng-plugins-mcp",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@linagora/lemonldap-ng-plugins-mcp",
+      "version": "0.1.0",
+      "license": "GPL-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.4"
+      },
+      "bin": {
+        "llng-plugins-mcp": "server.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+      "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
+      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.14",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
+      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+      "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,18 +1,19 @@
 {
   "name": "@linagora/lemonldap-ng-plugins-mcp",
-  "version": "0.1.0",
+  "version": "0.1.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@linagora/lemonldap-ng-plugins-mcp",
-      "version": "0.1.0",
+      "version": "0.1.20",
       "license": "GPL-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4"
       },
       "bin": {
-        "llng-plugins-mcp": "server.js"
+        "llng-plugins-mcp": "server.js",
+        "llng-plugins-test": "cli.js"
       },
       "engines": {
         "node": ">=18"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@linagora/lemonldap-ng-plugins-mcp",
+  "version": "0.1.20",
+  "description": "MCP server + CLI to prepare, run and clean local tests for LemonLDAP::NG plugins",
+  "type": "module",
+  "main": "server.js",
+  "bin": {
+    "llng-plugins-mcp": "server.js",
+    "llng-plugins-test": "cli.js"
+  },
+  "files": [
+    "server.js",
+    "cli.js",
+    "lib.js",
+    "README.md"
+  ],
+  "scripts": {
+    "start": "node server.js",
+    "test": "node cli.js"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.4"
+  },
+  "keywords": [
+    "mcp",
+    "lemonldap-ng",
+    "perl",
+    "test",
+    "plugins"
+  ],
+  "author": "Linagora",
+  "license": "GPL-2.0"
+}

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+// MCP server exposing the local-test helpers for LLNG plugins.
+// Core logic lives in lib.js (shared with cli.js).
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  cleanAll,
+  cleanTest,
+  executeTest,
+  listPluginDirs,
+  prepareTest,
+} from "./lib.js";
+
+const TOOLS = [
+  {
+    name: "list-plugins",
+    description:
+      "List plugins available in the plugins/ directory of this repository.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "prepare-test",
+    description:
+      "Clone LemonLDAP::NG into .llng-test/ (if needed), run `make common`, " +
+      "and symlink the plugin's lib/, t/, portal-templates/, portal-static/, " +
+      "manager-static/ into the LLNG tree, and merge portal-translations/ " +
+      "into the portal's languages/ directory. Plugins declared in " +
+      "`depends` (plugin.json) are linked transitively before the primary " +
+      "plugin; use `with` to add extra dependencies and `noDeps` to disable " +
+      "auto-resolution.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plugin: { type: "string", description: "Primary plugin name" },
+        with: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Extra plugins to link alongside the primary (lib + assets only; their tests are not linked).",
+        },
+        noDeps: {
+          type: "boolean",
+          default: false,
+          description: "Skip auto-resolution of `depends` in plugin.json.",
+        },
+        skipMake: {
+          type: "boolean",
+          default: false,
+          description: "Skip `make common` (useful on repeated runs).",
+        },
+      },
+      required: ["plugin"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "execute-test",
+    description:
+      "Run `prove -v -I. -I../lemonldap-ng-common/blib/lib " +
+      "-I../lemonldap-ng-handler/lib -I../lemonldap-ng-manager/lib " +
+      "-I../lemonldap-ng-portal/lib` inside the primary plugin's LLNG " +
+      "component directory. Requires prepare-test beforehand.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plugin: { type: "string", description: "Primary plugin name" },
+        tests: {
+          type: "array",
+          items: { type: "string" },
+          description:
+            "Optional explicit test paths relative to the component dir (or absolute). Defaults to every .t in the plugin's t/.",
+        },
+        verbose: { type: "boolean", default: true },
+      },
+      required: ["plugin"],
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "clean-test",
+    description:
+      "Remove symlinks created inside the LLNG clone and un-merge any " +
+      "translation keys that were added. Pass `plugin` or `plugins` to scope " +
+      "the cleanup; omit both to clean every plugin. The LLNG clone itself is kept.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plugin: { type: "string", description: "Single plugin to clean." },
+        plugins: {
+          type: "array",
+          items: { type: "string" },
+          description: "Explicit list of plugins to clean.",
+        },
+      },
+      additionalProperties: false,
+    },
+  },
+  {
+    name: "clean-all",
+    description:
+      "Full reset: remove every plugin symlink AND delete the .llng-test/ directory (including the LLNG clone). Use this to start from scratch.",
+    inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  },
+  {
+    name: "test",
+    description:
+      "Convenience: runs prepare-test then execute-test. Does not clean up.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        plugin: { type: "string" },
+        with: { type: "array", items: { type: "string" } },
+        noDeps: { type: "boolean", default: false },
+        skipMake: { type: "boolean", default: false },
+        tests: { type: "array", items: { type: "string" } },
+        verbose: { type: "boolean", default: true },
+      },
+      required: ["plugin"],
+      additionalProperties: false,
+    },
+  },
+];
+
+function textResult(obj) {
+  const text = typeof obj === "string" ? obj : JSON.stringify(obj, null, 2);
+  return { content: [{ type: "text", text }] };
+}
+
+function errorResult(err) {
+  return {
+    isError: true,
+    content: [
+      {
+        type: "text",
+        text: err instanceof Error ? err.stack || err.message : String(err),
+      },
+    ],
+  };
+}
+
+const server = new Server(
+  { name: "lemonldap-ng-plugins-mcp", version: "0.1.20" },
+  { capabilities: { tools: {} } },
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }));
+
+server.setRequestHandler(CallToolRequestSchema, async (req) => {
+  const { name, arguments: args = {} } = req.params;
+  try {
+    switch (name) {
+      case "list-plugins": {
+        const plugins = await listPluginDirs();
+        return textResult({ plugins, count: plugins.length });
+      }
+      case "prepare-test": {
+        const res = await prepareTest(args.plugin, {
+          skipMake: !!args.skipMake,
+          with: args.with || [],
+          noDeps: !!args.noDeps,
+        });
+        return textResult(res);
+      }
+      case "execute-test": {
+        const res = await executeTest(args.plugin, {
+          tests: args.tests,
+          verbose: args.verbose !== false,
+        });
+        return textResult(res);
+      }
+      case "clean-test": {
+        const scope = args.plugins
+          ? args.plugins
+          : args.plugin
+            ? [args.plugin]
+            : undefined;
+        const res = await cleanTest({ plugins: scope });
+        return textResult({
+          removed: res.removed,
+          removedCount: res.removed.length,
+          translationKeysRemoved: res.unmerged,
+        });
+      }
+      case "clean-all": {
+        const res = await cleanAll();
+        return textResult({
+          removedCount: res.removed.length,
+          translationKeysRemoved: res.unmerged,
+          clonedRemoved: res.clonedRemoved,
+          llngRoot: res.llngRoot,
+        });
+      }
+      case "test": {
+        const prep = await prepareTest(args.plugin, {
+          skipMake: !!args.skipMake,
+          with: args.with || [],
+          noDeps: !!args.noDeps,
+        });
+        const exec = await executeTest(args.plugin, {
+          tests: args.tests,
+          verbose: args.verbose !== false,
+        });
+        return textResult({
+          prepare: {
+            primary: prep.primary,
+            chain: prep.chain,
+            component: prep.component,
+            totals: prep.totals,
+            log: prep.log,
+          },
+          execute: exec,
+        });
+      }
+      default:
+        throw new Error(`Unknown tool: ${name}`);
+    }
+  } catch (e) {
+    return errorResult(e);
+  }
+});
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/mcp/server.js
+++ b/mcp/server.js
@@ -53,6 +53,11 @@ const TOOLS = [
           default: false,
           description: "Skip `make common` (useful on repeated runs).",
         },
+        ref: {
+          type: "string",
+          description:
+            "Clone LLNG at this git ref (tag or branch). Missing refs fall back to the default branch. Changing ref wipes the previous clone.",
+        },
       },
       required: ["plugin"],
       additionalProperties: false,
@@ -117,6 +122,7 @@ const TOOLS = [
         with: { type: "array", items: { type: "string" } },
         noDeps: { type: "boolean", default: false },
         skipMake: { type: "boolean", default: false },
+        ref: { type: "string" },
         tests: { type: "array", items: { type: "string" } },
         verbose: { type: "boolean", default: true },
       },
@@ -163,6 +169,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           skipMake: !!args.skipMake,
           with: args.with || [],
           noDeps: !!args.noDeps,
+          ref: args.ref || "",
         });
         return textResult(res);
       }
@@ -200,6 +207,7 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
           skipMake: !!args.skipMake,
           with: args.with || [],
           noDeps: !!args.noDeps,
+          ref: args.ref || "",
         });
         const exec = await executeTest(args.plugin, {
           tests: args.tests,
@@ -210,6 +218,8 @@ server.setRequestHandler(CallToolRequestSchema, async (req) => {
             primary: prep.primary,
             chain: prep.chain,
             component: prep.component,
+            ref: prep.ref,
+            refFallback: prep.refFallback,
             totals: prep.totals,
             log: prep.log,
           },

--- a/plugins/pam-access/plugin.json
+++ b/plugins/pam-access/plugin.json
@@ -10,6 +10,10 @@
     "JSON": "2.0"
   },
   "customPlugins": "::Plugins::PamAccess",
+  "depends": [
+    "oidc-device-authorization",
+    "ssh-ca"
+  ],
   "tags": [
     "pam",
     "ssh",

--- a/plugins/ssh-ca/README.md
+++ b/plugins/ssh-ca/README.md
@@ -81,12 +81,12 @@ Examples:
 
 ### User endpoints (authentication required)
 
-| Method | Path             | Description                                                                     |
-| ------ | ---------------- | ------------------------------------------------------------------------------- |
-| GET    | `/ssh`           | User interface for signing SSH keys                                             |
-| POST   | `/ssh/sign`      | Sign a user's SSH public key (requires a unique `label` among active certs)     |
-| GET    | `/ssh/mycerts`   | List the current user's certificates (JSON)                                     |
-| POST   | `/ssh/myrevoke`  | Self-revoke one of the caller's own certificates; immediately added to the KRL  |
+| Method | Path            | Description                                                                    |
+| ------ | --------------- | ------------------------------------------------------------------------------ |
+| GET    | `/ssh`          | User interface for signing SSH keys                                            |
+| POST   | `/ssh/sign`     | Sign a user's SSH public key (requires a unique `label` among active certs)    |
+| GET    | `/ssh/mycerts`  | List the current user's certificates (JSON)                                    |
+| POST   | `/ssh/myrevoke` | Self-revoke one of the caller's own certificates; immediately added to the KRL |
 
 ### Admin endpoints (authentication + access control required)
 


### PR DESCRIPTION
Ships a small Node.js toolchain under `mcp/` that automates the plumbing to run a plugin's Perl test suite against a [LemonLDAP::NG](https://linagora.com/) checkout: shallow-clones LLNG into `.llng-test/`, runs `make common`, symlinks the plugin's `lib/`, `t/`, `portal-templates/`, `portal-static/` and `manager-static/` into the LLNG tree, merges `portal-translations/` additively into the portal's `languages/` _(with per-plugin key tracking so cleanup un-merges only what it added)_, and runs [prove](https://manpages.debian.org/trixie/perl/prove.1.en.html) with the canonical -I flag set.

Transitive plugin dependencies declared in `plugin.json:depends` are linked before the primary plugin; only the primary's tests run.

Two entry points sharing lib.js:
- **server.js**: MCP server _(auto-loaded via `.mcp.json` for Claude Code and other MCP-aware clients)_.
- **cli.js** _(npm bin: llng-plugins-test)_: standalone CLI for humans and CI, with exit codes propagated from [prove](https://manpages.debian.org/trixie/perl/prove.1.en.html).

CONTRIBUTING.md documents both paths and the mandatory one-time `cd mcp && npm install`.