### PR TITLE
ssh-ca: harden /ssh/revoke session load

### DIFF
--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -364,6 +364,19 @@ sub sshCaSign {
         $val = $req->sessionInfo->{$key} if !defined $val || $val eq '';
         $val = ''                        if !defined $val;
 
+        # Strip characters that could turn a single attribute value into
+        # multiple principals downstream: `,` is ssh-keygen -n's separator
+        # (`-n alice,root` = two principals), whitespace is this template's
+        # own separator, and CR/LF would poison the audit log or any file
+        # passed to ssh-keygen. Each `$var` substitution must yield at most
+        # one principal token.
+        if ( $val =~ tr/,\r\n\t //d ) {
+            $self->logger->warn(
+                "SSH CA sign: stripped separator chars from principal "
+                  . "source \$$key for user "
+                  . ( $req->user || 'unknown' ) );
+        }
+
         $principal .= $val;
         $pos = $match_end;
     }

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -1113,15 +1113,30 @@ sub sshCertRevoke {
           || {},
     };
 
+    # Load the existing persistent session. `force => 1` would both skip
+    # existence checks AND create a fresh session row if the id is unknown —
+    # neither is wanted: admin revocation must only mutate a real persistent
+    # session that already carries _sshCerts.
     my $psession = Lemonldap::NG::Common::Session->new(
         {
             %$moduleOptions,
-            id    => $sessionId,
-            force => 1,
+            id => $sessionId,
         }
     );
 
     unless ( $psession && !$psession->error ) {
+        return $self->p->sendJSONresponse(
+            $req,
+            { error => 'Session not found' },
+            code => 404
+        );
+    }
+
+    # Refuse sessions that are not persistent (SSO/PAMTOKEN/DEVA/... all
+    # carry a different `_session_kind`). `sshCertsList` only ever exposes
+    # persistent session ids to the admin UI, so anything else here is a
+    # caller mistake or a forged request.
+    unless ( ( $psession->data->{_session_kind} // '' ) eq 'Persistent' ) {
         return $self->p->sendJSONresponse(
             $req,
             { error => 'Session not found' },

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -366,11 +366,13 @@ sub sshCaSign {
 
         # Strip characters that could turn a single attribute value into
         # multiple principals downstream: `,` is ssh-keygen -n's separator
-        # (`-n alice,root` = two principals), whitespace is this template's
-        # own separator, and CR/LF would poison the audit log or any file
-        # passed to ssh-keygen. Each `$var` substitution must yield at most
-        # one principal token.
-        if ( $val =~ tr/,\r\n\t //d ) {
+        # (`-n alice,root` = two principals), and any whitespace is the
+        # template's own separator (we split on /\s+/ below). CR/LF would
+        # additionally poison audit logs and any file handed to ssh-keygen.
+        # Each `$var` substitution must yield at most one principal token,
+        # so match the same `\s` class the split uses — `tr///` cannot do
+        # that, hence the regex.
+        if ( $val =~ s/[\s,]//g ) {
             $self->logger->warn(
                 "SSH CA sign: stripped separator chars from principal "
                   . "source \$$key for user "


### PR DESCRIPTION
Drop `force => 1` so an unknown session_id returns 404 instead of silently creating a ghost session row, and reject session ids whose _session_kind is not 'Persistent' — the admin UI only exposes persistent ids (sshCertsList scans `_session_kind=Persistent`), so anything else is a caller mistake or a forged request.

The persistent session that carries _sshCerts is created by sshCaSign -> _storeCertificate via updatePersistentSession, never by the revoke handler, so this does not regress the nominal flow.