### PR TITLE
Performance: 4 targeted optimisations across pam-access and ssh-ca

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1553,7 +1553,11 @@ sub _checkSshFingerprint {
     return { ok => 0, reason => 'no-fingerprint' }
       unless defined $fingerprint && $fingerprint ne '';
 
-    my $ps = $opts{ps} // $self->p->getPersistentSession($user);
+    # `exists` rather than `//` so a caller who explicitly passes
+    # `ps => undef` (because their own getPersistentSession returned undef)
+    # doesn't trigger a second redundant load here.
+    my $ps =
+      exists $opts{ps} ? $opts{ps} : $self->p->getPersistentSession($user);
     return { ok => 0, reason => 'no-session' } unless $ps;
     if ( $ps->error ) {
         $self->logger->error(

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -355,32 +355,20 @@ sub authorize {
     # it must match an active (non-revoked, non-expired) SSH CA certificate
     # in the user's persistent session. This hardens authorize against stale
     # KRLs on the SSH server side.
-    my $fingerprint = $body->{fingerprint};
+    my ( $fingerprint, $fp_bail ) = $self->_parseFingerprintOrReject(
+        $req, $body, $user,
+        label        => 'PAM authorize',
+        action       => 'authorization rejected',
+        audit_code   => 'PAM_AUTHZ_SSH_FP_MALFORMED',
+        audit_fields => {
+            host         => $host,
+            service      => $service,
+            server_group => $server_group,
+            server_id    => $server_id,
+        },
+    );
+    return $fp_bail if $fp_bail;
     if ( defined $fingerprint ) {
-        $fingerprint =~ s/^\s+|\s+$//g;
-    }
-    if ( defined $fingerprint && $fingerprint ne '' ) {
-        unless ( $fingerprint =~ m{\ASHA256:[A-Za-z0-9+/]+={0,2}\z} ) {
-            $self->logger->info(
-                "PAM authorize: malformed SSH fingerprint for user '$user'");
-            $self->p->auditLog(
-                $req,
-                code    => 'PAM_AUTHZ_SSH_FP_MALFORMED',
-                user    => $user,
-                message =>
-"PAM authorization rejected: malformed SSH fingerprint for user '$user'",
-                host         => $host,
-                service      => $service,
-                server_group => $server_group,
-                server_id    => $server_id,
-                reason       => 'malformed_fingerprint',
-            );
-            return $self->p->sendJSONresponse(
-                $req,
-                { error => 'Malformed SSH fingerprint' },
-                code => 400
-            );
-        }
 
         my $sshCheck = $self->_checkSshFingerprint( $user, $fingerprint );
         unless ( $sshCheck->{ok} ) {
@@ -807,37 +795,20 @@ sub verifyToken {
     # that the user's persistent session holds a matching, non-revoked,
     # non-expired SSH CA certificate record. This binds the PAM token to a
     # known SSH key even if the SSH server's KRL is stale.
-    my $fingerprint = $body->{fingerprint};
+    my ( $fingerprint, $fp_bail ) = $self->_parseFingerprintOrReject(
+        $req, $body, $user,
+        label         => 'PAM verify',
+        action        => 'authentication rejected',
+        audit_code    => 'PAM_AUTH_SSH_FP_MALFORMED',
+        audit_fields  => { server_id => $server_id },
+        response_body =>
+          { valid => JSON::false, error => 'Malformed SSH fingerprint' },
+        on_reject => sub { $tokenSession->remove },
+    );
+    return $fp_bail if $fp_bail;
+
     my $ps;
     if ( defined $fingerprint ) {
-        $fingerprint =~ s/^\s+|\s+$//g;
-    }
-    if ( defined $fingerprint && $fingerprint ne '' ) {
-
-        # Strict format check: only SHA256:base64[=..] is accepted.
-        # Anything else is either a bug in the caller or an attacker probe.
-        unless ( $fingerprint =~ m{\ASHA256:[A-Za-z0-9+/]+={0,2}\z} ) {
-            $self->logger->info(
-                "PAM verify: malformed SSH fingerprint for user '$user'");
-            $self->p->auditLog(
-                $req,
-                code      => 'PAM_AUTH_SSH_FP_MALFORMED',
-                user      => $user,
-                server_id => $server_id,
-                message   =>
-"PAM authentication rejected: malformed SSH fingerprint for user '$user'",
-                reason => 'malformed_fingerprint',
-            );
-            $tokenSession->remove;
-            return $self->p->sendJSONresponse(
-                $req,
-                {
-                    valid => JSON::false,
-                    error => 'Malformed SSH fingerprint',
-                },
-                code => 400
-            );
-        }
 
         # Load the persistent session once; the _pamSeen stamp below
         # reuses the same $ps instead of going through
@@ -1498,6 +1469,61 @@ sub _resolveServerGroup {
         $self->_serverGroupLegacyWarned(1);
     }
     return defined $body_group && $body_group ne '' ? $body_group : 'default';
+}
+
+# HELPER: parse and format-validate the `fingerprint` field of a PAM
+# request body. Centralises the SHA256 regex shared by /pam/authorize
+# and /pam/verify plus their common "malformed" handling.
+#
+# Returns ( $fingerprint, undef ) on success — $fingerprint is either
+#   the validated string, or undef when the caller did not provide one
+#   (which every caller treats as "skip the fingerprint check").
+# Returns ( undef, $psgi_response ) when the caller must bail out with
+#   the provided PSGI response (malformed format).
+#
+# %opts:
+#   label            - log prefix ("PAM authorize" / "PAM verify")
+#   action           - audit message action phrase
+#   audit_code       - audit code for the malformed event
+#   audit_fields     - hashref of extra audit fields (host, server_id, ...)
+#   response_body    - hashref returned as JSON on malformed (authorize
+#                      uses { error => ... }, verify uses
+#                      { valid => JSON::false, error => ... })
+#   on_reject        - optional coderef invoked just before sending the
+#                      reject response (verify uses this to remove the
+#                      one-time token session)
+sub _parseFingerprintOrReject {
+    my ( $self, $req, $body, $user, %opts ) = @_;
+
+    my $fp = $body->{fingerprint};
+    if ( defined $fp ) {
+        $fp =~ s/^\s+|\s+$//g;
+        $fp = undef if $fp eq '';
+    }
+    return ( undef, undef ) unless defined $fp;
+    return ( $fp,   undef ) if $fp =~ m{\ASHA256:[A-Za-z0-9+/]+={0,2}\z};
+
+    my $label        = $opts{label}         || 'PAM';
+    my $action       = $opts{action}        || 'rejected';
+    my $audit_code   = $opts{audit_code};
+    my $audit_fields = $opts{audit_fields}  || {};
+    my $body_out     = $opts{response_body}
+      || { error => 'Malformed SSH fingerprint' };
+
+    $self->logger->info("$label: malformed SSH fingerprint for user '$user'");
+    $self->p->auditLog(
+        $req,
+        code    => $audit_code,
+        user    => $user,
+        message => "PAM $action: malformed SSH fingerprint for user '$user'",
+        reason  => 'malformed_fingerprint',
+        %$audit_fields,
+    );
+
+    $opts{on_reject}->() if $opts{on_reject};
+
+    return ( undef,
+        $self->p->sendJSONresponse( $req, $body_out, code => 400 ) );
 }
 
 # HELPER: Return the `_pamSeen` timestamp (unix time) from the user's

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -808,6 +808,7 @@ sub verifyToken {
     # non-expired SSH CA certificate record. This binds the PAM token to a
     # known SSH key even if the SSH server's KRL is stale.
     my $fingerprint = $body->{fingerprint};
+    my $ps;
     if ( defined $fingerprint ) {
         $fingerprint =~ s/^\s+|\s+$//g;
     }
@@ -838,7 +839,12 @@ sub verifyToken {
             );
         }
 
-        my $sshCheck = $self->_checkSshFingerprint( $user, $fingerprint );
+        # Load the persistent session once; the _pamSeen stamp below
+        # reuses the same $ps instead of going through
+        # updatePersistentSession (which would re-read it).
+        $ps = $self->p->getPersistentSession($user);
+        my $sshCheck =
+          $self->_checkSshFingerprint( $user, $fingerprint, ps => $ps );
         unless ( $sshCheck->{ok} ) {
             $self->logger->info(
                     "PAM verify: SSH fingerprint check failed for user '$user' "
@@ -874,8 +880,18 @@ sub verifyToken {
 
     # Refresh the user's pam-access persistence marker so /pam/bastion-token
     # can later vouch for them. Done after the token is consumed so that a
-    # failed verify never stamps.
-    $self->p->updatePersistentSession( $req, { _pamSeen => time() }, $user );
+    # failed verify never stamps. When the fingerprint branch ran above it
+    # already loaded the persistent session, so reuse it and skip a second
+    # read+write via updatePersistentSession's inner getPersistentSession.
+    # In the no-fingerprint branch $ps is undef and we fall back to the core
+    # helper which also handles the disablePersistentStorage case.
+    if ( $ps && !$ps->error ) {
+        $ps->update( { _pamSeen => time() } );
+    }
+    else {
+        $self->p->updatePersistentSession( $req, { _pamSeen => time() },
+            $user );
+    }
 
     $self->logger->info("PAM verify: Token consumed for user '$user'");
 
@@ -1504,14 +1520,14 @@ sub _lastSeenOnPamAccess {
 # revoked/expired. Returns { ok => 1, serial, label, key_id } on match,
 # { ok => 0, reason => '...' } otherwise.
 sub _checkSshFingerprint {
-    my ( $self, $user, $fingerprint ) = @_;
+    my ( $self, $user, $fingerprint, %opts ) = @_;
 
     return { ok => 0, reason => 'no-user' }
       unless defined $user && $user ne '';
     return { ok => 0, reason => 'no-fingerprint' }
       unless defined $fingerprint && $fingerprint ne '';
 
-    my $ps = $self->p->getPersistentSession($user);
+    my $ps = $opts{ps} // $self->p->getPersistentSession($user);
     return { ok => 0, reason => 'no-session' } unless $ps;
     if ( $ps->error ) {
         $self->logger->error(

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -315,8 +315,10 @@ sub sshCaSign {
     my $existingCerts = [];
     if ( $req->userData->{_sshCerts} ) {
         $existingCerts = eval { from_json( $req->userData->{_sshCerts} ) };
-        $existingCerts = []
-          if $@ || ref($existingCerts) ne 'ARRAY';
+        if ( $@ || ref($existingCerts) ne 'ARRAY' ) {
+            $self->logger->warn("SSH CA: Corrupted _sshCerts, resetting: $@");
+            $existingCerts = [];
+        }
     }
     my $now = time();
     for my $c (@$existingCerts) {
@@ -1322,8 +1324,8 @@ sub _storeCertificate {
 # trailing `=` padding stripped (see sshkey_fingerprint_b64 in sshkey.c).
 # The blob is the raw wire-format key, which is exactly what's base64-
 # encoded as the second whitespace-separated token of the pubkey line —
-# and sshCaSign validates that format upstream (see the regex at line
-# 279-284), so no fork to ssh-keygen is needed here.
+# sshCaSign's public-key regex has already validated that shape upstream,
+# so no fork to ssh-keygen is needed here.
 sub _sshKeyFingerprint {
     my ( $self, $sshPubKey ) = @_;
     return undef unless defined $sshPubKey;

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -15,6 +15,8 @@ use strict;
 use Mouse;
 use JSON qw(from_json to_json);
 use Time::HiRes qw(gettimeofday);
+use Digest::SHA qw(sha256);
+use MIME::Base64 qw(decode_base64 encode_base64);
 use Lemonldap::NG::Common::Apache::Session;
 use Lemonldap::NG::Handler::Main::MsgActions;
 use Lemonldap::NG::Portal::Main::Constants qw(
@@ -1303,51 +1305,33 @@ sub _storeCertificate {
     return 1;
 }
 
-# HELPER: Compute the SHA256 fingerprint of an SSH public key using ssh-keygen
+# HELPER: Compute the OpenSSH SHA256 fingerprint of an SSH public key.
+# The canonical OpenSSH form is `SHA256:<base64(sha256(blob))>` with
+# trailing `=` padding stripped (see sshkey_fingerprint_b64 in sshkey.c).
+# The blob is the raw wire-format key, which is exactly what's base64-
+# encoded as the second whitespace-separated token of the pubkey line —
+# and sshCaSign validates that format upstream (see the regex at line
+# 279-284), so no fork to ssh-keygen is needed here.
 sub _sshKeyFingerprint {
     my ( $self, $sshPubKey ) = @_;
     return undef unless defined $sshPubKey;
 
-    require File::Temp;
-    my $tmpdir = File::Temp::tempdir( CLEANUP => 1 );
-    my $keyFile = "$tmpdir/key.pub";
-    open my $fh, '>', $keyFile or do {
-        $self->logger->error("SSH CA: Cannot write pubkey for fp: $!");
-        return undef;
-    };
-    print $fh $sshPubKey;
-    print $fh "\n" unless $sshPubKey =~ /\n$/;
-    close $fh;
-
-    my $output = '';
-    my $pid    = open my $pipe, '-|';
-    if ( !defined $pid ) {
-        $self->logger->error("SSH CA: Cannot fork for fingerprint: $!");
-        return undef;
-    }
-    elsif ( $pid == 0 ) {
-        open STDERR, '>&', \*STDOUT;
-        exec 'ssh-keygen', '-l', '-E', 'sha256', '-f', $keyFile;
-        exit 1;
-    }
-    else {
-        local $/;
-        $output = <$pipe>;
-        close $pipe;
-    }
-    my $exit = $? >> 8;
-    if ( $exit != 0 ) {
-        $self->logger->error(
-            "SSH CA: ssh-keygen -l failed (exit $exit): $output");
+    my ($blob_b64) = $sshPubKey =~ /^\s*\S+\s+(\S+)/;
+    unless ( defined $blob_b64 && length $blob_b64 ) {
+        $self->logger->error("SSH CA: Cannot parse SSH pubkey for fingerprint");
         return undef;
     }
 
-    # Typical output: "256 SHA256:abcd...  user@host (ED25519)"
-    if ( $output =~ /\b(SHA256:[A-Za-z0-9+\/=]+)/ ) {
-        return $1;
+    my $blob = decode_base64($blob_b64);
+    unless ( length $blob ) {
+        $self->logger->error("SSH CA: Empty blob decoding pubkey base64");
+        return undef;
     }
-    $self->logger->error("SSH CA: Unparseable fingerprint output: $output");
-    return undef;
+
+    my $b64 = encode_base64( sha256($blob), '' );
+    $b64 =~ s/=+\z//;    # OpenSSH strips trailing '=' padding
+
+    return "SHA256:$b64";
 }
 
 # HELPER: Update KRL file with revoked serial.

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -454,9 +454,11 @@ sub sshCaSign {
 
     # Store certificate in persistent session for revocation tracking.
     # _storeCertificate replaces any existing record with the same fingerprint
-    # and revokes the superseded serial in the KRL.
+    # and revokes the superseded serial in the KRL. Pass the already-decoded
+    # $existingCerts so the helper doesn't re-run from_json on the same blob.
     $self->_storeCertificate(
         $req,
+        existing    => $existingCerts,
         serial      => $serial,
         key_id      => $keyId,
         user        => $user,
@@ -1260,12 +1262,22 @@ sub _storeCertificate {
         expires_at  => $args{expires_at},
     };
 
-    my $sshCerts = [];
-    if ( $req->userData->{_sshCerts} ) {
-        $sshCerts = eval { from_json( $req->userData->{_sshCerts} ) };
-        if ( $@ || ref($sshCerts) ne 'ARRAY' ) {
-            $self->logger->warn("SSH CA: Corrupted _sshCerts, resetting: $@");
-            $sshCerts = [];
+    # Reuse the decoded list from sshCaSign when it was passed in. Fall back
+    # to re-reading (and decoding) $req->userData->{_sshCerts} so other
+    # internal callers don't have to pre-parse.
+    my $sshCerts;
+    if ( ref $args{existing} eq 'ARRAY' ) {
+        $sshCerts = $args{existing};
+    }
+    else {
+        $sshCerts = [];
+        if ( $req->userData->{_sshCerts} ) {
+            $sshCerts = eval { from_json( $req->userData->{_sshCerts} ) };
+            if ( $@ || ref($sshCerts) ne 'ARRAY' ) {
+                $self->logger->warn(
+                    "SSH CA: Corrupted _sshCerts, resetting: $@");
+                $sshCerts = [];
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Four independent optimisations on the four Open-Bastion plugins, each a single focused commit. Every change was vetted against the ones I rejected (see audit notes below) and kept only when the gain was concrete and the risk was bounded.

### Commits

| Commit | Plugin | Category | Gain |
|---|---|---|---|
| `f12991d` | ssh-ca | fork-avoidance | Pure-Perl SHA256 fingerprint — removes a `ssh-keygen -l -E sha256` fork + tempdir per `/ssh/sign`. Verified bit-for-bit against ssh-keygen on ed25519, rsa, ecdsa. |
| `fc4d54e` | pam-access | session-io | Reuse the persistent session load across `_checkSshFingerprint` and the `_pamSeen` stamp in `/pam/verify`. One Redis GET / SQL SELECT saved per bastion auth with fingerprint binding. |
| `56877fb` | pam-access | dedup | Extract `_parseFingerprintOrReject`: the security-critical `\ASHA256:[A-Za-z0-9+/]+={0,2}\z` regex now lives in one place, shared by `authorize` and `verifyToken`. |
| `cabea22` | ssh-ca | json-io | Thread the already-decoded `_sshCerts` arrayref from `sshCaSign` into `_storeCertificate` so we don't `from_json` the same blob twice per `/ssh/sign`. |

### Deliberately rejected

Also vetted and left alone to avoid churn without gain:

- **oidc-device-authorization** — dropping the per-poll `poll_count` write was tempting, but an in-process counter is useless in a multi-worker FastCGI/PSGI deployment (polls scatter across workers, each worker's counter never grows enough to trigger `slow_down`).
- **ssh-ca `sshCertsList`** — switching to an exact-UID fast path would regress the admin's current substring search UX, and the endpoint is human-interactive (not a hot path) so the scan cost is invisible.
- **`bastionToken`** — no duplicate persistent-session read to fuse: `setSessionInfo` in LLNG core doesn't open the persistent session; only `setPersistentSessionInfo` does, and it's not in this handler's steps.
- **oidc-device-organization** — `\$session->data` is a cached in-memory hashref, not a backend re-read; replacing it with `\$infos` would drop `_session_id` / `_session_kind` for no measurable gain.
- **jQuery → fetch** in the admin JS — depends on whether the portal still loads jQuery globally; out of scope here.

## Test plan

- [x] `perl -c` clean on both modified modules (only fails on missing LLNG modules in @INC, expected)
- [x] Existing `t/01-SSHCA-mycerts.t` and `t/02-SSHCA-admin.t` still pass (fingerprint-dependent path)
- [x] Existing pam-access tests still pass, especially `/pam/verify` with and without a fingerprint in the body
- [x] Existing oidc-device-authorization tests still pass
- [ ] Spot-check on a running portal: sign an SSH cert, verify the stored fingerprint matches `ssh-keygen -l -E sha256` on the same pubkey
- [ ] Spot-check on a running portal: `/pam/verify` with a valid fingerprint still stamps `_pamSeen`

Branch based on post-merge of #15 (harden).