### PR TITLE
Add oidc-rar plugin (RFC 9396 Rich Authorization Requests) + oidc-par fix

### DIFF
--- a/plugins/oidc-par/lib/Lemonldap/NG/Portal/Plugins/OIDCPushedAuthRequest.pm
+++ b/plugins/oidc-par/lib/Lemonldap/NG/Portal/Plugins/OIDCPushedAuthRequest.pm
@@ -88,7 +88,8 @@ sub pushAuthRequest {
     for my $param (
         qw/response_type scope client_id state redirect_uri nonce
         response_mode display prompt max_age ui_locales id_token_hint
-        login_hint acr_values request code_challenge code_challenge_method/
+        login_hint acr_values request code_challenge code_challenge_method
+        authorization_details/
       )
     {
         if ( defined( my $val = $req->param($param) ) ) {
@@ -227,7 +228,8 @@ sub resolvePushedRequest {
     # RFC 9126 Section 3: Parameters in the PAR response take precedence
     my @par_params = qw/response_type scope client_id state redirect_uri nonce
       response_mode display prompt max_age ui_locales id_token_hint
-      login_hint acr_values request code_challenge code_challenge_method/;
+      login_hint acr_values request code_challenge code_challenge_method
+      authorization_details/;
 
     for my $param (@par_params) {
         if ( defined $parSession->data->{$param} ) {

--- a/plugins/oidc-par/t/32-OIDC-PAR.t
+++ b/plugins/oidc-par/t/32-OIDC-PAR.t
@@ -320,6 +320,40 @@ subtest "PAR missing required parameters fails" => sub {
     is( $json2->{error}, "invalid_request", "Error is invalid_request" );
 };
 
+subtest "PAR forwards authorization_details (RFC 9396)" => sub {
+
+    # Client pushes a request that carries authorization_details (used by the
+    # oidc-rar plugin). PAR must store it and forward it through the
+    # request_uri exchange to the authorize endpoint.
+    my $details = '[{"type":"payment_initiation","amount":"42"}]';
+    my $par_res = parRequest(
+        $op, "rp",
+        {
+            %test_authorize_params,
+            client_id             => "rp",
+            authorization_details => $details,
+        }
+    );
+    is( $par_res->[0], 201, "PAR with authorization_details returns 201" );
+    my $par_json = parJSON($par_res);
+    ok( $par_json->{request_uri},
+        "request_uri returned for RAR-carrying PAR" );
+
+    # The authorize endpoint resolves the request_uri; reaching the redirect
+    # confirms the parameter survived storage and round-tripped without
+    # tripping a validation error.
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            client_id   => "rp",
+            request_uri => $par_json->{request_uri},
+        }
+    );
+    my ($code) = expectRedirection( $auth_res, qr#http://.*code=([^\&]*)# );
+    ok( $code,
+        "Authorize after RAR-carrying PAR yields a code (param survived)" );
+};
+
 clean_sessions();
 done_testing();
 

--- a/plugins/oidc-par/t/32-OIDC-PAR.t
+++ b/plugins/oidc-par/t/32-OIDC-PAR.t
@@ -320,11 +320,12 @@ subtest "PAR missing required parameters fails" => sub {
     is( $json2->{error}, "invalid_request", "Error is invalid_request" );
 };
 
-subtest "PAR forwards authorization_details (RFC 9396)" => sub {
+subtest "PAR accepts the authorization_details parameter (RFC 9396)" => sub {
 
-    # Client pushes a request that carries authorization_details (used by the
-    # oidc-rar plugin). PAR must store it and forward it through the
-    # request_uri exchange to the authorize endpoint.
+    # Verifies that the push side does not reject `authorization_details` as
+    # an unknown parameter. End-to-end semantics (the parameter actually
+    # surfaces in the token response) require oidc-rar to be active, and
+    # are covered by the corresponding subtest in oidc-rar's test suite.
     my $details = '[{"type":"payment_initiation","amount":"42"}]';
     my $par_res = parRequest(
         $op, "rp",
@@ -338,20 +339,6 @@ subtest "PAR forwards authorization_details (RFC 9396)" => sub {
     my $par_json = parJSON($par_res);
     ok( $par_json->{request_uri},
         "request_uri returned for RAR-carrying PAR" );
-
-    # The authorize endpoint resolves the request_uri; reaching the redirect
-    # confirms the parameter survived storage and round-tripped without
-    # tripping a validation error.
-    my $auth_res = authorize(
-        $op, $id,
-        {
-            client_id   => "rp",
-            request_uri => $par_json->{request_uri},
-        }
-    );
-    my ($code) = expectRedirection( $auth_res, qr#http://.*code=([^\&]*)# );
-    ok( $code,
-        "Authorize after RAR-carrying PAR yields a code (param survived)" );
 };
 
 clean_sessions();

--- a/plugins/oidc-rar/README.md
+++ b/plugins/oidc-rar/README.md
@@ -21,8 +21,8 @@ constrain it). Example for an open-banking payment initiation:
   {
     "type": "payment_initiation",
     "instructedAmount": { "currency": "EUR", "amount": "100.00" },
-    "creditorAccount":  { "iban": "FR7612345...." },
-    "creditorName":     "Acme Corp"
+    "creditorAccount": { "iban": "FR7612345...." },
+    "creditorName": "Acme Corp"
   }
 ]
 ```
@@ -44,24 +44,31 @@ sudo lemonldap-ng-store install oidc-rar
 
 Manually: copy `lib/` into your Perl `@INC` path, copy `manager-overrides/`
 into `/etc/lemonldap-ng/manager-plugins.d/`, add
-`::Plugins::OIDCRichAuthRequest` to *Custom plugins*, and run
+`::Plugins::OIDCRichAuthRequest` to _Custom plugins_, and run
 `llng-build-manager-files`.
 
 ## Configuration
 
-### Service-level (Manager → *OpenID Connect Service* → *Security*)
+### Service-level (Manager → _OpenID Connect Service_ → _Security_)
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
+| Parameter                              | Default | Description                                                                                                                  |
+| -------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------- |
 | `oidcServiceAuthorizationDetailsTypes` | _empty_ | Global allowlist of accepted `type` values, comma-separated. Empty = no global restriction (per-RP allowlist still applies). |
 
-### Per-RP (Manager → *OIDC Relying Parties* → `<rp>` → *Options* → *Security*)
+### Per-RP
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| `oidcRPMetaDataOptionsAuthorizationDetailsEnabled` | `0` | Accept `authorization_details` from this RP. Required to trigger plugin autoload. |
-| `oidcRPMetaDataOptionsAuthorizationDetailsTypes` | _empty_ | Per-RP allowlist of `type` values, comma-separated. Empty = inherit global only. |
-| `oidcRPMetaDataOptionsAuthorizationDetailsRule` | _empty_ | Perl expression evaluated for each requested entry. |
+In **Manager → _OIDC Relying Parties_ → `<rp>` → _Options_ → _Security_** :
+
+| Parameter                                          | Default | Description                                                                       |
+| -------------------------------------------------- | ------- | --------------------------------------------------------------------------------- |
+| `oidcRPMetaDataOptionsAuthorizationDetailsEnabled` | `0`     | Accept `authorization_details` from this RP. Required to trigger plugin autoload. |
+| `oidcRPMetaDataOptionsAuthorizationDetailsTypes`   | _empty_ | Per-RP allowlist of `type` values, comma-separated. Empty = inherit global only.  |
+
+In **Manager → _OIDC Relying Parties_ → `<rp>` → _Options_ → _Scopes_ → _Authorization details rules_** :
+
+| Parameter                                  | Default | Description                                                                                                                                              |
+| ------------------------------------------ | ------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `oidcRPMetaDataAuthorizationDetailsRules`  | `{}`    | Hash `type → Perl expression`. Mirrors the `oidcRPMetaDataScopeRules` mechanism: each rule is evaluated when an entry of the matching `type` is requested. |
 
 ### Authorization model — three layers
 
@@ -71,13 +78,13 @@ Every requested `authorization_details` entry must clear all three:
    `oidcServiceAuthorizationDetailsTypes` ∩
    `oidcRPMetaDataOptionsAuthorizationDetailsTypes`. Either set being empty
    means "no restriction at that level". Both empty means any type goes.
-2. **Per-RP Perl rule** — if `oidcRPMetaDataOptionsAuthorizationDetailsRule`
-   is set, it is evaluated in LLNG's sandbox (`Safe::reval`) for each entry,
-   with the user session attributes plus two magic variables:
-   - `$type` — the entry's `type` value
-   - `$detail` — the full hashref of the entry
-   Truthy result grants the entry; falsy rejects it (whole authorize call
-   fails).
+2. **Per-RP, per-type Perl rule** — if a rule is configured for the
+   requested entry's `type` in `oidcRPMetaDataAuthorizationDetailsRules`,
+   it is evaluated in LLNG's sandbox (`Safe::reval`), with the user session
+   attributes plus the magic variable `$detail` (full hashref of the
+   entry). Truthy result grants the entry; falsy rejects it (whole authorize
+   call fails). Types with no entry in this hash skip layer 2 (granted
+   subject to layer 1).
 3. **User consent** — for the `authorization_code` flow only, the operator's
    consent template (`oidcGiveConsent.tpl` / `oidcConsents.tpl`) can display
    `RAR_DETAILS` (a pretty-printed JSON summary of the pending entries) so
@@ -93,25 +100,23 @@ Every requested `authorization_details` entry must clear all three:
 
 #### Example rules
 
-```perl
-# Only allow payment_initiation if user is in the banking group
-$type ne 'payment_initiation' or $groups =~ /\bbanking\b/
+In `oidcRPMetaDataAuthorizationDetailsRules` for an RP, key = `type`, value
+= Perl expression:
 
-# Cap payment amounts based on authentication level
-$type ne 'payment_initiation'
-  or ( $detail->{instructedAmount}->{amount} <= 1000
-       or $authenticationLevel >= 4 )
+```
+payment_initiation  =>  $groups =~ /\bbanking\b/ and $detail->{instructedAmount}->{amount} <= 1000
+account_information =>  $authenticationLevel >= 2
 ```
 
 ## Where the granted details surface
 
-| Location | Mechanism |
-|----------|-----------|
-| `/oauth2/token` JSON response | Top-level `authorization_details` field |
-| JWT access token | `authorization_details` claim (only when LLNG issues structured/JWT access tokens for the RP) |
-| `/oauth2/introspect` response | Top-level `authorization_details` field |
+| Location                            | Mechanism                                                                                                                               |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `/oauth2/token` JSON response       | Top-level `authorization_details` field                                                                                                 |
+| JWT access token                    | `authorization_details` claim (only when LLNG issues structured/JWT access tokens for the RP)                                           |
+| `/oauth2/introspect` response       | Top-level `authorization_details` field                                                                                                 |
 | `/.well-known/openid-configuration` | `authorization_details_types_supported` array (union of all enabled RPs' allowed types, intersected with the global allowlist when set) |
-| Refresh token grant | Persisted on the refresh session, re-emitted in the new token response |
+| Refresh token grant                 | Persisted on the refresh session, re-emitted in the new token response                                                                  |
 
 ## Limitations & known gaps (v1)
 

--- a/plugins/oidc-rar/README.md
+++ b/plugins/oidc-rar/README.md
@@ -85,18 +85,38 @@ Every requested `authorization_details` entry must clear all three:
    entry). Truthy result grants the entry; falsy rejects it (whole authorize
    call fails). Types with no entry in this hash skip layer 2 (granted
    subject to layer 1).
-3. **User consent** — for the `authorization_code` flow only, the operator's
-   consent template (`oidcGiveConsent.tpl` / `oidcConsents.tpl`) can display
-   `RAR_DETAILS` (a pretty-printed JSON summary of the pending entries) so
-   the end-user can decide. The variable is **HTML-escaped before injection**
-   (`HTML::Entities::encode_entities`), so it is safe to render verbatim
-   inside `<pre>` / `<code>` without `ESCAPE=HTML`. Example template snippet:
+3. **User consent** *(optional, depending on the use case)* — when
+   `BypassConsent=0` for the RP, the operator's consent template
+   (`oidcGiveConsent.tpl` / `oidcConsents.tpl`) can display `RAR_DETAILS`
+   (a pretty-printed JSON summary of the pending entries). The variable is
+   **HTML-escaped before injection** (`HTML::Entities::encode_entities`), so
+   it is safe to render verbatim inside `<pre>` / `<code>` without
+   `ESCAPE=HTML`. Example template snippet:
+
    ```html
    <TMPL_IF NAME="RAR_DETAILS">
      <h4>Requested authorization details</h4>
      <pre><TMPL_VAR NAME="RAR_DETAILS"></pre>
    </TMPL_IF>
    ```
+
+   With `BypassConsent=1`, layer 3 is skipped — authorization is entirely
+   carried by layers 1 and 2.
+
+## Two usage modes
+
+RAR fits two quite different deployment patterns; pick the one that
+matches your environment:
+
+| Mode                     | Source of truth                                | `BypassConsent` | Typical context                                              |
+| ------------------------ | ---------------------------------------------- | --------------- | ------------------------------------------------------------ |
+| **B2C / regulated**      | The end-user's informed consent on each call   | `0`             | PSD2 open banking, healthcare, anywhere the law requires it  |
+| **B2B / enterprise**     | The operator's policy (allowlist + Perl rules) | `1`             | Internal SSO, automation, B2B integrations, service accounts |
+
+In B2C the user is the gatekeeper; the consent screen *is* the policy.
+In B2B the user is just identified; the policy is fully expressed in the
+allowlist and rules, and the consent screen is unnecessary friction. The
+plugin supports both — it never forces a consent screen.
 
 #### Example rules
 

--- a/plugins/oidc-rar/README.md
+++ b/plugins/oidc-rar/README.md
@@ -1,0 +1,137 @@
+# OIDC RAR — Rich Authorization Requests (RFC 9396)
+
+This plugin implements [RFC 9396 — OAuth 2.0 Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+on the LemonLDAP::NG OIDC Provider side.
+
+It accepts an `authorization_details` JSON parameter on `/oauth2/authorize`,
+validates it against a per-RP allowlist and an optional Perl rule, persists
+the granted entries through the authorization_code and refresh_token flows,
+and echoes them in the token response, the JWT access token, and the
+introspection response. The supported types are advertised in the
+`/.well-known/openid-configuration` document.
+
+## What `authorization_details` looks like
+
+A JSON array of objects, each carrying at least a `type` discriminator. The
+shape of the remaining fields is type-specific (the spec deliberately does not
+constrain it). Example for an open-banking payment initiation:
+
+```json
+[
+  {
+    "type": "payment_initiation",
+    "instructedAmount": { "currency": "EUR", "amount": "100.00" },
+    "creditorAccount":  { "iban": "FR7612345...." },
+    "creditorName":     "Acme Corp"
+  }
+]
+```
+
+The client passes this URL-encoded on the authorize endpoint:
+
+```
+GET /oauth2/authorize?response_type=code&client_id=...&redirect_uri=...
+    &scope=openid&state=...&authorization_details=%5B%7B...%7D%5D
+```
+
+## Installation
+
+With `lemonldap-ng-store` (LLNG ≥ 2.23.0):
+
+```bash
+sudo lemonldap-ng-store install oidc-rar
+```
+
+Manually: copy `lib/` into your Perl `@INC` path, copy `manager-overrides/`
+into `/etc/lemonldap-ng/manager-plugins.d/`, add
+`::Plugins::OIDCRichAuthRequest` to *Custom plugins*, and run
+`llng-build-manager-files`.
+
+## Configuration
+
+### Service-level (Manager → *OpenID Connect Service* → *Security*)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `oidcServiceAuthorizationDetailsTypes` | _empty_ | Global allowlist of accepted `type` values, comma-separated. Empty = no global restriction (per-RP allowlist still applies). |
+
+### Per-RP (Manager → *OIDC Relying Parties* → `<rp>` → *Options* → *Security*)
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `oidcRPMetaDataOptionsAuthorizationDetailsEnabled` | `0` | Accept `authorization_details` from this RP. Required to trigger plugin autoload. |
+| `oidcRPMetaDataOptionsAuthorizationDetailsTypes` | _empty_ | Per-RP allowlist of `type` values, comma-separated. Empty = inherit global only. |
+| `oidcRPMetaDataOptionsAuthorizationDetailsRule` | _empty_ | Perl expression evaluated for each requested entry. |
+
+### Authorization model — three layers
+
+Every requested `authorization_details` entry must clear all three:
+
+1. **Type allowlist** — entry's `type` must be in
+   `oidcServiceAuthorizationDetailsTypes` ∩
+   `oidcRPMetaDataOptionsAuthorizationDetailsTypes`. Either set being empty
+   means "no restriction at that level". Both empty means any type goes.
+2. **Per-RP Perl rule** — if `oidcRPMetaDataOptionsAuthorizationDetailsRule`
+   is set, it is evaluated in LLNG's sandbox (`Safe::reval`) for each entry,
+   with the user session attributes plus two magic variables:
+   - `$type` — the entry's `type` value
+   - `$detail` — the full hashref of the entry
+   Truthy result grants the entry; falsy rejects it (whole authorize call
+   fails).
+3. **User consent** — for the `authorization_code` flow only, the operator's
+   consent template should display `RAR_DETAILS` (a pretty-printed JSON
+   summary of the pending entries) so the end-user can decide.
+
+#### Example rules
+
+```perl
+# Only allow payment_initiation if user is in the banking group
+$type ne 'payment_initiation' or $groups =~ /\bbanking\b/
+
+# Cap payment amounts based on authentication level
+$type ne 'payment_initiation'
+  or ( $detail->{instructedAmount}->{amount} <= 1000
+       or $authenticationLevel >= 4 )
+```
+
+## Where the granted details surface
+
+| Location | Mechanism |
+|----------|-----------|
+| `/oauth2/token` JSON response | Top-level `authorization_details` field |
+| JWT access token | `authorization_details` claim (only when LLNG issues structured/JWT access tokens for the RP) |
+| `/oauth2/introspect` response | Top-level `authorization_details` field |
+| `/.well-known/openid-configuration` | `authorization_details_types_supported` array (union of all enabled RPs' allowed types, intersected with the global allowlist when set) |
+| Refresh token grant | Persisted on the refresh session, re-emitted in the new token response |
+
+## Limitations & known gaps (v1)
+
+- **No token-endpoint scope-down.** The client cannot submit a sub-set of
+  `authorization_details` at the token endpoint to narrow the grant
+  (RFC 9396 §3, optional feature).
+- **No type-specific structural validation.** The plugin checks the generic
+  shape (array of objects, each with a `type` string) but does not validate
+  type-specific fields. Combine the Perl rule + a per-type validator plugin
+  if you need to enforce structure.
+- **No client-side support yet.** This plugin is OP-only. A
+  `OIDCRichAuthRequestClient.pm` for LLNG-as-RP is planned as a follow-up.
+- **No dynamic registration support.** `authorization_details_types` in the
+  client metadata at `/oauth2/register` is not honored. Add it via a custom
+  `oidcRegisterClient` hook in your own plugin if needed.
+- **Errors do not RFC-redirect.** A failed validation triggers a portal
+  error page rather than a `error=invalid_authorization_details` redirect to
+  the RP. Acceptable for v1; refining this requires `PE_SENDRESPONSE` with a
+  custom redirect.
+
+## Combining with PAR (RFC 9126)
+
+Since this PR also patches `oidc-par`, `authorization_details` is forwarded
+correctly through pushed authorization requests. Push it on `/oauth2/par`
+along with the other parameters; the resulting `request_uri` carries it to
+`/oauth2/authorize` transparently.
+
+## See also
+
+- [RFC 9396 — OAuth 2.0 Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396)
+- [LemonLDAP::NG OIDC hooks](https://lemonldap-ng.org/documentation/latest/hooks)
+- [`oidc-par`](../oidc-par/) — Pushed Authorization Requests (RFC 9126)

--- a/plugins/oidc-rar/README.md
+++ b/plugins/oidc-rar/README.md
@@ -79,8 +79,17 @@ Every requested `authorization_details` entry must clear all three:
    Truthy result grants the entry; falsy rejects it (whole authorize call
    fails).
 3. **User consent** — for the `authorization_code` flow only, the operator's
-   consent template should display `RAR_DETAILS` (a pretty-printed JSON
-   summary of the pending entries) so the end-user can decide.
+   consent template (`oidcGiveConsent.tpl` / `oidcConsents.tpl`) can display
+   `RAR_DETAILS` (a pretty-printed JSON summary of the pending entries) so
+   the end-user can decide. The variable is **HTML-escaped before injection**
+   (`HTML::Entities::encode_entities`), so it is safe to render verbatim
+   inside `<pre>` / `<code>` without `ESCAPE=HTML`. Example template snippet:
+   ```html
+   <TMPL_IF NAME="RAR_DETAILS">
+     <h4>Requested authorization details</h4>
+     <pre><TMPL_VAR NAME="RAR_DETAILS"></pre>
+   </TMPL_IF>
+   ```
 
 #### Example rules
 

--- a/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
+++ b/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
@@ -10,6 +10,7 @@ package Lemonldap::NG::Portal::Plugins::OIDCRichAuthRequest;
 use strict;
 use Mouse;
 use JSON qw(decode_json);
+use HTML::Entities qw(encode_entities);
 use Lemonldap::NG::Portal::Main::Constants qw(
   PE_OK
   PE_ERROR
@@ -338,6 +339,11 @@ sub advertiseTypes {
 # Inject a pretty-printed JSON view of pending authorization_details for the
 # OIDC consent template, so deployments that render the variable can show it
 # to the user.
+#
+# The content of `authorization_details` is RP-controlled and lands in HTML,
+# so we HTML-escape on the way out: HTML::Template does not auto-escape, and
+# operators may forget to add `ESCAPE=HTML` on `<TMPL_VAR NAME="RAR_DETAILS">`.
+# Pre-escaping makes the variable safe to render verbatim inside <pre>/<code>.
 sub injectConsentDetails {
     my ( $self, $req, $tpl, $args ) = @_;
 
@@ -346,8 +352,8 @@ sub injectConsentDetails {
     my $d = $req->data->{ &SESSION_KEY };
     return PE_OK unless $d;
 
-    $args->{params}->{ &CONSENT_TPL_VAR } =
-      JSON->new->canonical->pretty->encode($d);
+    my $json = JSON->new->canonical->pretty->encode($d);
+    $args->{params}->{ &CONSENT_TPL_VAR } = encode_entities($json);
     return PE_OK;
 }
 

--- a/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
+++ b/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
@@ -16,7 +16,7 @@ use Lemonldap::NG::Portal::Main::Constants qw(
   PE_ERROR
 );
 
-our $VERSION = '0.1.0';
+our $VERSION = '2.23.0';
 
 extends 'Lemonldap::NG::Portal::Lib::OIDCPlugin';
 
@@ -98,8 +98,10 @@ sub _buildRpRarRule {
         my $expr = $self->p->HANDLER->substitute($rule);
         my $sub  = $self->p->HANDLER->buildSub($expr);
         unless ($sub) {
-            $self->logger->error( "RAR: cannot compile rule for RP $rp: "
-                  . $self->p->HANDLER->tsv->{jail}->error );
+            my $err = $self->p->HANDLER->tsv->{jail}->error || '???';
+            $self->userLogger->error( "RAR: cannot compile rule for RP $rp: "
+                  . "$err — falling back to deny-all to fail closed" );
+            $compiled{$rp} = sub { 0 };
             next;
         }
         $compiled{$rp} = $sub;

--- a/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
+++ b/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
@@ -88,23 +88,30 @@ sub _buildRpAllowedTypes {
 sub _buildRpRarRule {
     my ($self) = @_;
     my %compiled;
-    my $opts = $self->conf->{oidcRPMetaDataOptions} || {};
+    my $opts  = $self->conf->{oidcRPMetaDataOptions}              || {};
+    my $rules = $self->conf->{oidcRPMetaDataAuthorizationDetailsRules} || {};
     for my $rp ( keys %$opts ) {
         next
           unless $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsEnabled};
-        my $rule = $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsRule};
-        next unless defined $rule and length $rule;
+        my $perType = $rules->{$rp} or next;
+        next unless ref($perType) eq 'HASH' and %$perType;
 
-        my $expr = $self->p->HANDLER->substitute($rule);
-        my $sub  = $self->p->HANDLER->buildSub($expr);
-        unless ($sub) {
-            my $err = $self->p->HANDLER->tsv->{jail}->error || '???';
-            $self->userLogger->error( "RAR: cannot compile rule for RP $rp: "
-                  . "$err — falling back to deny-all to fail closed" );
-            $compiled{$rp} = sub { 0 };
-            next;
+        for my $type ( keys %$perType ) {
+            my $rule = $perType->{$type};
+            next unless defined $rule and length $rule;
+
+            my $expr = $self->p->HANDLER->substitute($rule);
+            my $sub  = $self->p->HANDLER->buildSub($expr);
+            unless ($sub) {
+                my $err = $self->p->HANDLER->tsv->{jail}->error || '???';
+                $self->userLogger->error( "RAR: cannot compile rule for RP "
+                      . "$rp / type $type: $err — falling back to deny-all "
+                      . "to fail closed" );
+                $compiled{$rp}{$type} = sub { 0 };
+                next;
+            }
+            $compiled{$rp}{$type} = $sub;
         }
-        $compiled{$rp} = $sub;
     }
     return \%compiled;
 }
@@ -206,17 +213,18 @@ sub enforceRulesAndStoreOnCode {
 
     my $details = $req->data->{ &SESSION_KEY } or return PE_OK;
 
-    my $rule = $self->rpRarRule->{$rp};
-    if ($rule) {
+    my $rpRules = $self->rpRarRule->{$rp};
+    if ( $rpRules and %$rpRules ) {
         for my $detail (@$details) {
+            my $type = $detail->{type};
+            my $rule = $rpRules->{$type} or next;
             my $attrs = {
                 %{ $req->userData || {} },
-                type   => $detail->{type},
                 detail => $detail,
             };
             unless ( $rule->( $req, $attrs ) ) {
                 $self->logger->error( "RAR: Perl rule rejected detail of "
-                      . "type `$detail->{type}` for RP $rp" );
+                      . "type `$type` for RP $rp" );
                 return PE_ERROR;
             }
         }

--- a/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
+++ b/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
@@ -1,0 +1,354 @@
+# RFC 9396 - OAuth 2.0 Rich Authorization Requests (RAR)
+#
+# This plugin adds support for the `authorization_details` parameter on the
+# OIDC Provider side. It validates and persists the parameter through the
+# authorization_code and refresh_token flows, echoes it in token responses,
+# exposes it as a JWT access token claim and via introspection, and
+# advertises supported types in the discovery document.
+package Lemonldap::NG::Portal::Plugins::OIDCRichAuthRequest;
+
+use strict;
+use Mouse;
+use JSON qw(decode_json);
+use Lemonldap::NG::Portal::Main::Constants qw(
+  PE_OK
+  PE_ERROR
+);
+
+our $VERSION = '0.1.0';
+
+extends 'Lemonldap::NG::Portal::Lib::OIDCPlugin';
+
+use constant SESSION_KEY      => '_rar_details';
+use constant CONSENT_TPL_VAR  => 'RAR_DETAILS';
+
+use constant hook => {
+    oidcGotRequest                    => 'parseAuthorizationDetails',
+    oidcGenerateCode                  => 'enforceRulesAndStoreOnCode',
+    oidcGotTokenRequest               => 'loadDetailsAtTokenEndpoint',
+    oidcGenerateRefreshToken          => 'storeOnRefresh',
+    oidcGotOnlineRefresh              => 'restoreFromRefresh',
+    oidcGotOfflineRefresh             => 'restoreFromRefresh',
+    oidcGenerateAccessToken           => 'addToAccessToken',
+    oidcGenerateTokenResponse         => 'addToTokenResponse',
+    oidcGenerateIntrospectionResponse => 'addToIntrospection',
+    oidcGenerateMetadata              => 'advertiseTypes',
+    sendHtml                          => 'injectConsentDetails',
+};
+
+has globalAllowedTypes => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_buildGlobalAllowedTypes',
+);
+
+has rpAllowedTypes => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_buildRpAllowedTypes',
+);
+
+has rpRarRule => (
+    is      => 'ro',
+    lazy    => 1,
+    builder => '_buildRpRarRule',
+);
+
+sub init {
+    my ($self) = @_;
+    return unless $self->SUPER::init;
+
+    # Force lazy builders so configuration errors surface at init time
+    $self->globalAllowedTypes;
+    $self->rpAllowedTypes;
+    $self->rpRarRule;
+
+    return 1;
+}
+
+sub _buildGlobalAllowedTypes {
+    my ($self) = @_;
+    return _parseTypeList( $self->conf->{oidcServiceAuthorizationDetailsTypes} );
+}
+
+sub _buildRpAllowedTypes {
+    my ($self) = @_;
+    my %map;
+    my $opts = $self->conf->{oidcRPMetaDataOptions} || {};
+    for my $rp ( keys %$opts ) {
+        next
+          unless $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsEnabled};
+        $map{$rp} = _parseTypeList(
+            $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsTypes} );
+    }
+    return \%map;
+}
+
+sub _buildRpRarRule {
+    my ($self) = @_;
+    my %compiled;
+    my $opts = $self->conf->{oidcRPMetaDataOptions} || {};
+    for my $rp ( keys %$opts ) {
+        next
+          unless $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsEnabled};
+        my $rule = $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsRule};
+        next unless defined $rule and length $rule;
+
+        my $expr = $self->p->HANDLER->substitute($rule);
+        my $sub  = $self->p->HANDLER->buildSub($expr);
+        unless ($sub) {
+            $self->logger->error( "RAR: cannot compile rule for RP $rp: "
+                  . $self->p->HANDLER->tsv->{jail}->error );
+            next;
+        }
+        $compiled{$rp} = $sub;
+    }
+    return \%compiled;
+}
+
+sub _parseTypeList {
+    my ($list) = @_;
+    return {} unless defined $list and length $list;
+    my %set;
+    for my $t ( split /\s*,\s*/, $list ) {
+        $set{$t} = 1 if length $t;
+    }
+    return \%set;
+}
+
+# Hook: oidcGotRequest
+# Layer 1 only (type allowlist). The Perl rule is enforced later, once user
+# attributes are known, in oidcGenerateCode.
+#
+# `authorization_details` is not in the core's hardcoded parameter list
+# (Issuer/OpenIDConnect.pm), so it is absent from $oidc_request — read it
+# directly from $req. Echo it back into $oidc_request for downstream hooks.
+sub parseAuthorizationDetails {
+    my ( $self, $req, $oidc_request ) = @_;
+
+    # PAR (oidc-par plugin) populates $oidc_request from a stored PAR session;
+    # direct authorize calls go through $req->param. Try both.
+    my $raw = $oidc_request->{authorization_details}
+      // $req->param('authorization_details');
+    return PE_OK unless defined $raw and length $raw;
+    $oidc_request->{authorization_details} = $raw;
+
+    my $client_id = $oidc_request->{client_id};
+    my $rp        = $client_id ? $self->oidc->getRP($client_id) : undef;
+    unless ($rp) {
+        $self->logger->error(
+            "RAR: client_id $client_id has no matching RP, ignoring "
+              . "authorization_details" );
+        return PE_OK;
+    }
+
+    unless ( $self->oidc->rpOptions->{$rp}
+        ->{oidcRPMetaDataOptionsAuthorizationDetailsEnabled} )
+    {
+        $self->logger->error("RAR: not enabled for RP $rp");
+        return PE_ERROR;
+    }
+
+    my $details = eval { decode_json($raw) };
+    if ($@) {
+        $self->logger->error("RAR: malformed authorization_details JSON: $@");
+        return PE_ERROR;
+    }
+
+    unless ( ref($details) eq 'ARRAY' and @$details ) {
+        $self->logger->error(
+            "RAR: authorization_details must be a non-empty JSON array");
+        return PE_ERROR;
+    }
+
+    my $globalSet = $self->globalAllowedTypes;
+    my $rpSet     = $self->rpAllowedTypes->{$rp} || {};
+
+    for my $detail (@$details) {
+        unless ( ref($detail) eq 'HASH' ) {
+            $self->logger->error("RAR: each detail must be a JSON object");
+            return PE_ERROR;
+        }
+        my $type = $detail->{type};
+        unless ( defined $type and !ref($type) and length $type ) {
+            $self->logger->error(
+                "RAR: each detail must have a non-empty `type` string");
+            return PE_ERROR;
+        }
+        if ( %$globalSet and !$globalSet->{$type} ) {
+            $self->logger->error(
+                "RAR: type `$type` not in service-level allowlist");
+            return PE_ERROR;
+        }
+        if ( %$rpSet and !$rpSet->{$type} ) {
+            $self->logger->error(
+                "RAR: type `$type` not in RP `$rp` allowlist");
+            return PE_ERROR;
+        }
+    }
+
+    $req->data->{ &SESSION_KEY } = $details;
+    $self->logger->debug(
+        "RAR: validated " . scalar(@$details) . " authorization_details" );
+
+    return PE_OK;
+}
+
+# Hook: oidcGenerateCode
+# Runs after authentication and consent. Enforces the per-RP Perl rule against
+# the now-known user attributes, then persists granted details on the code
+# session so subsequent token/refresh calls can echo them.
+sub enforceRulesAndStoreOnCode {
+    my ( $self, $req, $oidc_request, $rp, $code_payload ) = @_;
+
+    my $details = $req->data->{ &SESSION_KEY } or return PE_OK;
+
+    my $rule = $self->rpRarRule->{$rp};
+    if ($rule) {
+        for my $detail (@$details) {
+            my $attrs = {
+                %{ $req->userData || {} },
+                type   => $detail->{type},
+                detail => $detail,
+            };
+            unless ( $rule->( $req, $attrs ) ) {
+                $self->logger->error( "RAR: Perl rule rejected detail of "
+                      . "type `$detail->{type}` for RP $rp" );
+                return PE_ERROR;
+            }
+        }
+    }
+
+    $code_payload->{ &SESSION_KEY } = $details;
+    return PE_OK;
+}
+
+# Hook: oidcGotTokenRequest
+# At /oauth2/token entry, $req->data is empty (back-channel call). Load
+# _rar_details from the code session (authorization_code grant) or the refresh
+# session (refresh_token grant) so the rest of the token-endpoint hook chain
+# can find them on $req->data.
+sub loadDetailsAtTokenEndpoint {
+    my ( $self, $req, $rp, $grant_type ) = @_;
+
+    if ( $grant_type eq 'authorization_code' ) {
+        my $code = $req->param('code') or return PE_OK;
+        my $codeSession = $self->oidc->getAuthorizationCode($code) or return PE_OK;
+        if ( my $d = $codeSession->data->{ &SESSION_KEY } ) {
+            $req->data->{ &SESSION_KEY } = $d;
+        }
+    }
+    elsif ( $grant_type eq 'refresh_token' ) {
+        my $rt = $req->param('refresh_token') or return PE_OK;
+        my $refreshSession = $self->oidc->getRefreshToken($rt) or return PE_OK;
+        if ( my $d = $refreshSession->data->{ &SESSION_KEY } ) {
+            $req->data->{ &SESSION_KEY } = $d;
+        }
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateRefreshToken
+# Persist details on the refresh session so refresh_token grants can echo them.
+sub storeOnRefresh {
+    my ( $self, $req, $refresh_info, $rp, $offline ) = @_;
+
+    my $details = $req->data->{ &SESSION_KEY };
+    $refresh_info->{ &SESSION_KEY } = $details if $details;
+    return PE_OK;
+}
+
+# Hooks: oidcGotOnlineRefresh / oidcGotOfflineRefresh
+# Restore details from the refresh session into $req->data so the rest of the
+# token response pipeline (addToAccessToken, addToTokenResponse) can find them.
+sub restoreFromRefresh {
+    my ( $self, $req, $rp, $refreshInfo, $sessionInfo ) = @_;
+
+    if ( my $d = $refreshInfo->{ &SESSION_KEY } ) {
+        $req->data->{ &SESSION_KEY } = $d;
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateAccessToken
+# Add authorization_details claim to JWT-formatted access tokens (RFC 9396 §7).
+# Also persists the details onto the access token session so introspection
+# (oidcGenerateIntrospectionResponse) can surface them.
+sub addToAccessToken {
+    my ( $self, $req, $payload, $rp, $extra_headers ) = @_;
+    my $d = $req->data->{ &SESSION_KEY } or return PE_OK;
+
+    $payload->{authorization_details} = $d;
+    if ( my $jti = $payload->{jti} ) {
+        $self->oidc->updateToken( $jti, { &SESSION_KEY => $d } );
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateTokenResponse
+# Echo authorization_details in the token endpoint JSON response (RFC 9396 §6).
+sub addToTokenResponse {
+    my ( $self, $req, $rp, $tokensResponse, $oidcSession, $userSession,
+        $grant_type ) = @_;
+
+    my $d = $oidcSession->{ &SESSION_KEY } || $req->data->{ &SESSION_KEY };
+    $tokensResponse->{authorization_details} = $d if $d;
+    return PE_OK;
+}
+
+# Hook: oidcGenerateIntrospectionResponse
+# Expose authorization_details on RFC 7662 introspection (RFC 9396 §10).
+sub addToIntrospection {
+    my ( $self, $req, $response, $rp, $token_data ) = @_;
+    if ( my $d = $token_data->{ &SESSION_KEY } ) {
+        $response->{authorization_details} = $d;
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateMetadata
+# Advertise authorization_details_types_supported in /.well-known/openid-configuration
+# (RFC 9396 §11). Computed as the union of every enabled RP's allowed types,
+# intersected with the global allowlist when set.
+sub advertiseTypes {
+    my ( $self, $req, $metadata ) = @_;
+
+    my %union;
+    for my $rp ( keys %{ $self->rpAllowedTypes } ) {
+        $union{$_} = 1 for keys %{ $self->rpAllowedTypes->{$rp} };
+    }
+    my $globalSet = $self->globalAllowedTypes;
+    if ( %$globalSet ) {
+        if ( %union ) {
+            %union = map { $_ => 1 } grep { $globalSet->{$_} } keys %union;
+        }
+        else {
+            %union = %$globalSet;
+        }
+    }
+
+    if ( %union ) {
+        $metadata->{authorization_details_types_supported} =
+          [ sort keys %union ];
+    }
+    return PE_OK;
+}
+
+# Hook: sendHtml
+# Inject a pretty-printed JSON view of pending authorization_details for the
+# OIDC consent template, so deployments that render the variable can show it
+# to the user.
+sub injectConsentDetails {
+    my ( $self, $req, $tpl, $args ) = @_;
+
+    return PE_OK unless $$tpl and $$tpl =~ /^oidc.*Consent/;
+
+    my $d = $req->data->{ &SESSION_KEY };
+    return PE_OK unless $d;
+
+    $args->{params}->{ &CONSENT_TPL_VAR } =
+      JSON->new->canonical->pretty->encode($d);
+    return PE_OK;
+}
+
+1;

--- a/plugins/oidc-rar/manager-overrides/rar.json
+++ b/plugins/oidc-rar/manager-overrides/rar.json
@@ -15,10 +15,11 @@
       "default": "",
       "documentation": "RFC 9396 — per-RP allowlist of authorization_details `type` values (comma-separated). Empty = inherit global only."
     },
-    "oidcRPMetaDataOptionsAuthorizationDetailsRule": {
-      "type": "text",
-      "default": "",
-      "documentation": "RFC 9396 — Perl expression evaluated for each requested authorization_details entry. Receives the user session attributes plus magic variables `$type` (entry type) and `$detail` (full hashref). Truthy result grants the entry, falsy rejects it. Empty = always grant."
+    "oidcRPMetaDataAuthorizationDetailsRules": {
+      "type": "keyTextContainer",
+      "keyTest": "^[\\x21\\x23-\\x5B\\x5D-\\x7E]+$",
+      "default": {},
+      "documentation": "RFC 9396 — per-`type` Perl rules. Key: authorization_details `type` identifier (RFC 6749 token charset). Value: Perl expression evaluated when an entry of that type is requested. Receives the user session attributes plus the magic variable `$detail` (full hashref of the entry). Truthy result grants the entry, falsy rejects it. A type that has no rule entry is permitted (subject to the type allowlist)."
     }
   },
   "tree": [
@@ -35,8 +36,15 @@
       "insert_after": "oidcRPMetaDataOptionsRequirePKCE",
       "nodes": [
         "oidcRPMetaDataOptionsAuthorizationDetailsEnabled",
-        "oidcRPMetaDataOptionsAuthorizationDetailsTypes",
-        "oidcRPMetaDataOptionsAuthorizationDetailsRule"
+        "oidcRPMetaDataOptionsAuthorizationDetailsTypes"
+      ]
+    },
+    "_oidcRPMetaDataNodeRarRules": {
+      "target": "oidcRPMetaDataNode",
+      "insert_into": "oidcRPMetaDataOptions/oidcRPMetaDataOptionsScopes",
+      "insert_after": "oidcRPMetaDataScopeRules",
+      "nodes": [
+        "oidcRPMetaDataAuthorizationDetailsRules"
       ]
     }
   },
@@ -53,9 +61,9 @@
       "en": "RAR — allowed types for this RP",
       "fr": "RAR — types autorisés pour ce RP"
     },
-    "oidcRPMetaDataOptionsAuthorizationDetailsRule": {
-      "en": "RAR — Perl rule for this RP",
-      "fr": "RAR — règle Perl pour ce RP"
+    "oidcRPMetaDataAuthorizationDetailsRules": {
+      "en": "RAR — Authorization details rules",
+      "fr": "RAR — Règles d'authorization details"
     }
   }
 }

--- a/plugins/oidc-rar/manager-overrides/rar.json
+++ b/plugins/oidc-rar/manager-overrides/rar.json
@@ -63,7 +63,7 @@
     },
     "oidcRPMetaDataAuthorizationDetailsRules": {
       "en": "RAR — Authorization details rules",
-      "fr": "RAR — Règles d'authorization details"
+      "fr": "RAR — Règles des détails d'autorisation"
     }
   }
 }

--- a/plugins/oidc-rar/manager-overrides/rar.json
+++ b/plugins/oidc-rar/manager-overrides/rar.json
@@ -1,0 +1,61 @@
+{
+  "attributes": {
+    "oidcServiceAuthorizationDetailsTypes": {
+      "type": "text",
+      "default": "",
+      "documentation": "RFC 9396 — global allowlist of authorization_details `type` values (comma-separated). Empty = no global restriction (per-RP allowlist still applies)."
+    },
+    "oidcRPMetaDataOptionsAuthorizationDetailsEnabled": {
+      "type": "bool",
+      "default": 0,
+      "documentation": "RFC 9396 — accept authorization_details parameter from this RP"
+    },
+    "oidcRPMetaDataOptionsAuthorizationDetailsTypes": {
+      "type": "text",
+      "default": "",
+      "documentation": "RFC 9396 — per-RP allowlist of authorization_details `type` values (comma-separated). Empty = inherit global only."
+    },
+    "oidcRPMetaDataOptionsAuthorizationDetailsRule": {
+      "type": "text",
+      "default": "",
+      "documentation": "RFC 9396 — Perl expression evaluated for each requested authorization_details entry. Receives the user session attributes plus magic variables `$type` (entry type) and `$detail` (full hashref). Truthy result grants the entry, falsy rejects it. Empty = always grant."
+    }
+  },
+  "tree": [
+    {
+      "insert_into": "oidcServiceMetaData/oidcServiceMetaDataSecurity",
+      "nodes": [
+        "oidcServiceAuthorizationDetailsTypes"
+      ]
+    }
+  ],
+  "ctrees": {
+    "oidcRPMetaDataNode": {
+      "insert_into": "oidcRPMetaDataOptions/security",
+      "insert_after": "oidcRPMetaDataOptionsRequirePKCE",
+      "nodes": [
+        "oidcRPMetaDataOptionsAuthorizationDetailsEnabled",
+        "oidcRPMetaDataOptionsAuthorizationDetailsTypes",
+        "oidcRPMetaDataOptionsAuthorizationDetailsRule"
+      ]
+    }
+  },
+  "lang": {
+    "oidcServiceAuthorizationDetailsTypes": {
+      "en": "RAR — global allowed types",
+      "fr": "RAR — types autorisés (global)"
+    },
+    "oidcRPMetaDataOptionsAuthorizationDetailsEnabled": {
+      "en": "RAR — Rich Authorization Requests enabled",
+      "fr": "RAR — Activer les requêtes d'autorisation enrichies"
+    },
+    "oidcRPMetaDataOptionsAuthorizationDetailsTypes": {
+      "en": "RAR — allowed types for this RP",
+      "fr": "RAR — types autorisés pour ce RP"
+    },
+    "oidcRPMetaDataOptionsAuthorizationDetailsRule": {
+      "en": "RAR — Perl rule for this RP",
+      "fr": "RAR — règle Perl pour ce RP"
+    }
+  }
+}

--- a/plugins/oidc-rar/plugin.json
+++ b/plugins/oidc-rar/plugin.json
@@ -1,0 +1,24 @@
+{
+  "name": "oidc-rar",
+  "version": "0.1.0",
+  "summary": "OAuth 2.0 Rich Authorization Requests (RFC 9396)",
+  "description": "Implements RFC 9396 Rich Authorization Requests on the OIDC Provider side: parses, validates and persists the authorization_details parameter, echoes it in token responses, exposes it as a JWT claim and via introspection, and advertises supported types in the discovery document. Per-RP allowlist and per-type Perl rules (sandboxed via Safe::reval, mirroring the existing scopeRules mechanism) decide which details are granted.",
+  "author": "LemonLDAP::NG team <lemonldap-ng@ow2.org>",
+  "license": "GPL-2.0",
+  "llng_compat": ">=2.23.0",
+  "perl_requires": {
+    "JSON": "2.0"
+  },
+  "customPlugins": "::Plugins::OIDCRichAuthRequest",
+  "tags": [
+    "oidc",
+    "security"
+  ],
+  "homepage": "https://github.com/linagora/lemonldap-ng-plugins",
+  "autoload": [
+    {
+      "condition": "or::oidcRPMetaDataOptions/*/oidcRPMetaDataOptionsAuthorizationDetailsEnabled",
+      "module": "::Plugins::OIDCRichAuthRequest"
+    }
+  ]
+}

--- a/plugins/oidc-rar/plugin.json
+++ b/plugins/oidc-rar/plugin.json
@@ -7,7 +7,8 @@
   "license": "GPL-2.0",
   "llng_compat": ">=2.23.0",
   "perl_requires": {
-    "JSON": "2.0"
+    "JSON": "2.0",
+    "HTML::Entities": "0"
   },
   "customPlugins": "::Plugins::OIDCRichAuthRequest",
   "tags": [

--- a/plugins/oidc-rar/t/35-OIDC-RAR.t
+++ b/plugins/oidc-rar/t/35-OIDC-RAR.t
@@ -222,6 +222,22 @@ subtest "Perl rule grants detail when condition holds" => sub {
         "small payment is granted by rule" );
 };
 
+subtest "Uncompilable Perl rule fails closed (deny-all)" => sub {
+    # rp_badrule has a syntactically broken rule; the plugin must install a
+    # deny-all fallback rather than silently dropping the rule (which would
+    # weaken authorization).
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp_badrule",
+            authorization_details => $valid_details,
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "broken rule denies all RAR requests for the RP" );
+};
+
 subtest "RP without RAR enabled rejects authorization_details" => sub {
     my $auth_res = authorize(
         $op, $id,
@@ -313,9 +329,10 @@ sub op {
                   'payment_initiation,account_information',
 
                 oidcRPMetaDataExportedVars => {
-                    rp        => { email => "mail", name => "cn", groups => "groups" },
-                    rp_strict => { email => "mail", name => "cn", groups => "groups" },
-                    rp_norar  => { email => "mail", name => "cn", groups => "groups" },
+                    rp         => { email => "mail", name => "cn", groups => "groups" },
+                    rp_strict  => { email => "mail", name => "cn", groups => "groups" },
+                    rp_norar   => { email => "mail", name => "cn", groups => "groups" },
+                    rp_badrule => { email => "mail", name => "cn", groups => "groups" },
                 },
                 oidcServiceAllowAuthorizationCodeFlow => 1,
                 oidcServiceAllowOffline               => 1,
@@ -362,6 +379,20 @@ sub op {
                         oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
                         oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
                         # RAR disabled
+                    },
+                    rp_badrule => {
+                        oidcRPMetaDataOptionsDisplayName            => "RP BadRule",
+                        oidcRPMetaDataOptionsIDTokenExpiration      => 3600,
+                        oidcRPMetaDataOptionsClientID               => "rp_badrule",
+                        oidcRPMetaDataOptionsClientSecret           => "rp_badrule",
+                        oidcRPMetaDataOptionsIDTokenSignAlg         => "RS256",
+                        oidcRPMetaDataOptionsBypassConsent          => 1,
+                        oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
+                        oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
+                        oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
+                        # Syntactically broken Perl: must trigger fail-closed
+                        oidcRPMetaDataOptionsAuthorizationDetailsRule =>
+                          'this is not valid perl ((',
                     },
                 },
                 oidcServicePrivateKeySig => oidc_key_op_private_sig,

--- a/plugins/oidc-rar/t/35-OIDC-RAR.t
+++ b/plugins/oidc-rar/t/35-OIDC-RAR.t
@@ -4,6 +4,7 @@ use strict;
 use IO::String;
 use MIME::Base64 qw/encode_base64/;
 use JSON;
+use Lemonldap::NG::Portal::Main::Request;
 
 BEGIN {
     require 't/test-lib.pm';
@@ -232,6 +233,46 @@ subtest "RP without RAR enabled rejects authorization_details" => sub {
     );
     expectPortalError( $auth_res, 24,
         "RAR-disabled RP returns portal error when details are sent" );
+};
+
+subtest "Consent template variable is HTML-escaped (XSS prevention)" => sub {
+    my $plugin = $op->p->loadedModules->{
+        'Lemonldap::NG::Portal::Plugins::OIDCRichAuthRequest' };
+    ok( $plugin, "RAR plugin is loaded" );
+
+    my $req = Lemonldap::NG::Portal::Main::Request->new( {} );
+    $req->data->{_rar_details} = [ {
+            type => "payment_initiation",
+            note => '<script>alert(1)</script>',
+            html => '<img src=x onerror="alert(2)">',
+    } ];
+    my $tpl  = "oidcGiveConsent";
+    my $args = { params => {} };
+
+    $plugin->injectConsentDetails( $req, \$tpl, $args );
+    my $out = $args->{params}->{RAR_DETAILS};
+    ok( $out, "RAR_DETAILS variable is set" );
+    unlike( $out, qr/<script>/,
+        "raw <script> tag is not present in the rendered variable" );
+    unlike( $out, qr/<img/,
+        "raw <img> tag is not present in the rendered variable" );
+    like( $out, qr/&lt;script&gt;/, "<script> is HTML-encoded" );
+    like( $out, qr/&quot;/,        '" is HTML-encoded' );
+};
+
+subtest "Consent injection skips non-consent OIDC templates" => sub {
+    my $plugin = $op->p->loadedModules->{
+        'Lemonldap::NG::Portal::Plugins::OIDCRichAuthRequest' };
+    my $req = Lemonldap::NG::Portal::Main::Request->new( {} );
+    $req->data->{_rar_details} = [ { type => "payment_initiation" } ];
+
+    for my $tpl_name (qw/oidcLogout oidcOfflineTokens login/) {
+        my $tpl  = $tpl_name;
+        my $args = { params => {} };
+        $plugin->injectConsentDetails( $req, \$tpl, $args );
+        ok( !exists $args->{params}->{RAR_DETAILS},
+            "$tpl_name template is left alone" );
+    }
 };
 
 subtest "Request without authorization_details still works" => sub {

--- a/plugins/oidc-rar/t/35-OIDC-RAR.t
+++ b/plugins/oidc-rar/t/35-OIDC-RAR.t
@@ -6,6 +6,12 @@ use MIME::Base64 qw/encode_base64/;
 use JSON;
 use Lemonldap::NG::Portal::Main::Request;
 
+# Skip the PAR + RAR end-to-end subtest when oidc-par's lib hasn't been
+# linked alongside oidc-rar (it's only linked when the test was prepared
+# with `with: ["oidc-par"]`). All other subtests run unconditionally.
+my $par_available =
+  eval { require Lemonldap::NG::Portal::Plugins::OIDCPushedAuthRequest; 1 };
+
 BEGIN {
     require 't/test-lib.pm';
     require 't/oidc-lib.pm';
@@ -291,6 +297,73 @@ subtest "Consent injection skips non-consent OIDC templates" => sub {
     }
 };
 
+SKIP: {
+    skip "oidc-par not linked (run with: ['oidc-par'])", 1
+      unless $par_available;
+
+    subtest "PAR + RAR end-to-end (companion patch in oidc-par)" => sub {
+        my $op2 = register( 'op_par_rar', sub { op_par_rar() } );
+        ok( $op2, "OP with PAR+RAR loaded" );
+        my $id2 = login( $op2, "french" );
+
+        # Push authorization_details through PAR
+        my $details = encode_json( [ {
+                type             => "payment_initiation",
+                instructedAmount => { currency => "EUR", amount => "42.00" },
+        } ] );
+        my $par_query = buildForm( {
+                response_type         => "code",
+                scope                 => "openid profile",
+                state                 => "par-rar",
+                redirect_uri          => "http://rp.com/",
+                client_id             => "rp",
+                authorization_details => $details,
+        } );
+        my $par_res = $op2->_post(
+            "/oauth2/par",
+            IO::String->new($par_query),
+            accept => 'application/json',
+            length => length($par_query),
+            custom => {
+                HTTP_AUTHORIZATION => "Basic "
+                  . encode_base64( "rp:rp", '' ),
+            },
+        );
+        is( $par_res->[0], 201, "PAR push accepted" );
+        my $par_json = from_json( $par_res->[2]->[0] );
+        ok( $par_json->{request_uri}, "request_uri returned" );
+
+        # Authorize with the request_uri only
+        my $auth_res = authorize(
+            $op2, $id2,
+            {
+                client_id   => "rp",
+                request_uri => $par_json->{request_uri},
+            }
+        );
+        my ($code) =
+          expectRedirection( $auth_res, qr#http://.*code=([^\&]*)# );
+        ok( $code, "Authorization code received through PAR" );
+
+        # Token response must echo authorization_details — the proof the
+        # parameter actually flowed: PAR push → PAR session → authorize
+        # → code session → token response.
+        my $token_res = expectJSON(
+            codeGrant( $op2, "rp", $code, "http://rp.com/" )
+        );
+        ok( $token_res->{authorization_details},
+            "authorization_details surfaced in token response" );
+        is( $token_res->{authorization_details}->[0]->{type},
+            "payment_initiation", "type preserved end-to-end" );
+        is(
+            $token_res->{authorization_details}->[0]
+              ->{instructedAmount}->{amount},
+            "42.00",
+            "payload preserved end-to-end"
+        );
+    };
+}
+
 subtest "Request without authorization_details still works" => sub {
     my $auth_res = authorize(
         $op, $id,
@@ -400,6 +473,52 @@ sub op {
                     rp_badrule => {
                         # Syntactically broken Perl: must trigger fail-closed
                         payment_initiation => 'this is not valid perl ((',
+                    },
+                },
+                oidcServicePrivateKeySig => oidc_key_op_private_sig,
+                oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+            }
+        }
+    );
+}
+
+# Config used by the "PAR + RAR end-to-end" subtest. Loads both plugins and
+# enables RAR + PAR on a single RP, so a `resource` push that carries
+# `authorization_details` can be observed all the way to the token response.
+sub op_par_rar {
+    return LLNG::Manager::Test->new( {
+            ini => {
+                domain                          => 'idp.com',
+                portal                          => 'http://auth.op.com/',
+                authentication                  => 'Demo',
+                userDB                          => 'Same',
+                customPlugins                   =>
+                  '::Plugins::OIDCPushedAuthRequest, '
+                  . '::Plugins::OIDCRichAuthRequest',
+                issuerDBOpenIDConnectActivation => "1",
+                restSessionServer               => 1,
+
+                oidcServiceMetaDataPushedAuthURI => 'par',
+                oidcServicePushedAuthExpiration  => 60,
+
+                oidcRPMetaDataExportedVars => {
+                    rp => { email => "mail", name => "cn", groups => "groups" },
+                },
+                oidcServiceAllowAuthorizationCodeFlow => 1,
+                oidcRPMetaDataOptions                 => {
+                    rp => {
+                        oidcRPMetaDataOptionsDisplayName           => "RP",
+                        oidcRPMetaDataOptionsIDTokenExpiration     => 3600,
+                        oidcRPMetaDataOptionsClientID              => "rp",
+                        oidcRPMetaDataOptionsClientSecret          => "rp",
+                        oidcRPMetaDataOptionsIDTokenSignAlg        => "RS256",
+                        oidcRPMetaDataOptionsBypassConsent         => 1,
+                        oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                        oidcRPMetaDataOptionsRedirectUris    => 'http://rp.com/',
+                        oidcRPMetaDataOptionsPAR             => 'allowed',
+                        oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
+                        oidcRPMetaDataOptionsAuthorizationDetailsTypes   =>
+                          'payment_initiation',
                     },
                 },
                 oidcServicePrivateKeySig => oidc_key_op_private_sig,

--- a/plugins/oidc-rar/t/35-OIDC-RAR.t
+++ b/plugins/oidc-rar/t/35-OIDC-RAR.t
@@ -1,0 +1,331 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use MIME::Base64 qw/encode_base64/;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+}
+
+my ( $op, $res );
+
+ok( $op = register( 'op', sub { op() } ), 'OP portal' );
+
+my $id = login( $op, "french" );
+
+my %base_authorize = (
+    response_type => "code",
+    scope         => "openid profile",
+    state         => "af0ifjsldkj",
+    redirect_uri  => "http://rp.com/",
+);
+
+my $valid_details = encode_json( [ {
+        type             => "payment_initiation",
+        instructedAmount => { currency => "EUR", amount => "100.00" },
+} ] );
+
+subtest "Discovery advertises authorization_details_types_supported" => sub {
+    my $res = $op->_get(
+        "/.well-known/openid-configuration",
+        accept => 'application/json',
+    );
+    my $json = expectJSON($res);
+    ok( $json->{authorization_details_types_supported},
+        "authorization_details_types_supported is present" );
+    is_deeply(
+        [ sort @{ $json->{authorization_details_types_supported} } ],
+        [ "account_information", "payment_initiation" ],
+        "supported types are correct"
+    );
+};
+
+subtest "Valid authorization_details echoed in token response" => sub {
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp",
+            authorization_details => $valid_details,
+        }
+    );
+    my ($code) = expectRedirection( $auth_res, qr#http://.*code=([^\&]*)# );
+    ok( $code, "Authorization code received" );
+
+    my $token_res = expectJSON(
+        codeGrant( $op, "rp", $code, "http://rp.com/" )
+    );
+    ok( $token_res->{authorization_details},
+        "authorization_details echoed in token response" );
+    is( $token_res->{authorization_details}->[0]->{type},
+        "payment_initiation", "echoed type matches" );
+    is( $token_res->{authorization_details}->[0]->{instructedAmount}
+          ->{amount},
+        "100.00", "echoed payload matches" );
+};
+
+subtest "JWT access token carries authorization_details claim" => sub {
+    my $code = codeAuthorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp",
+            authorization_details => $valid_details,
+        }
+    );
+    my $token_res = expectJSON(
+        codeGrant( $op, "rp", $code, "http://rp.com/" )
+    );
+    my $payload = getJWTPayload( $token_res->{access_token} );
+    ok( $payload, "Access token is a JWT" );
+    ok( $payload->{authorization_details},
+        "authorization_details claim present in JWT" );
+    is( $payload->{authorization_details}->[0]->{type},
+        "payment_initiation", "claim type matches" );
+};
+
+subtest "Introspection includes authorization_details" => sub {
+    my $code = codeAuthorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp",
+            authorization_details => $valid_details,
+        }
+    );
+    my $token_res = expectJSON(
+        codeGrant( $op, "rp", $code, "http://rp.com/" )
+    );
+    my $intro = expectJSON(
+        introspect( $op, "rp", $token_res->{access_token} ) );
+    ok( $intro->{authorization_details},
+        "authorization_details present in introspection" );
+    is( $intro->{authorization_details}->[0]->{type},
+        "payment_initiation", "introspected type matches" );
+};
+
+subtest "Refresh token preserves authorization_details" => sub {
+    my $code = codeAuthorize(
+        $op, $id,
+        {
+            %base_authorize,
+            scope                 => "openid profile offline_access",
+            client_id             => "rp",
+            authorization_details => $valid_details,
+        }
+    );
+    my $token_res = expectJSON(
+        codeGrant( $op, "rp", $code, "http://rp.com/" )
+    );
+    ok( $token_res->{refresh_token}, "refresh_token issued" );
+
+    my $query = buildForm( {
+            grant_type    => "refresh_token",
+            refresh_token => $token_res->{refresh_token},
+    } );
+    my $refresh_res = $op->_post(
+        "/oauth2/token",
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+        custom => {
+            HTTP_AUTHORIZATION => "Basic " . encode_base64( "rp:rp", '' ),
+        },
+    );
+    my $refresh_json = expectJSON($refresh_res);
+    ok( $refresh_json->{authorization_details},
+        "refresh response includes authorization_details" );
+    is( $refresh_json->{authorization_details}->[0]->{type},
+        "payment_initiation", "refresh keeps original type" );
+};
+
+subtest "Type not in allowlist is rejected" => sub {
+    my $bad = encode_json( [ { type => "ride_hailing" } ] );
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp",
+            authorization_details => $bad,
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "type outside allowlist returns portal error" );
+};
+
+subtest "Malformed JSON is rejected" => sub {
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp",
+            authorization_details => "not_json{",
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "malformed JSON returns portal error" );
+};
+
+subtest "Detail missing `type` is rejected" => sub {
+    my $bad = encode_json( [ { foo => "bar" } ] );
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp",
+            authorization_details => $bad,
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "detail without `type` returns portal error" );
+};
+
+subtest "Perl rule rejects detail when condition fails" => sub {
+    # rp_strict has a rule requiring detail->{instructedAmount}{amount} <= 50
+    my $over = encode_json( [ {
+            type             => "payment_initiation",
+            instructedAmount => { currency => "EUR", amount => "9999.00" },
+    } ] );
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp_strict",
+            authorization_details => $over,
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "rule rejection returns portal error" );
+};
+
+subtest "Perl rule grants detail when condition holds" => sub {
+    my $ok_detail = encode_json( [ {
+            type             => "payment_initiation",
+            instructedAmount => { currency => "EUR", amount => "10.00" },
+    } ] );
+    my $code = codeAuthorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp_strict",
+            authorization_details => $ok_detail,
+        }
+    );
+    my $token_res = expectJSON(
+        codeGrant( $op, "rp_strict", $code, "http://rp.com/" )
+    );
+    ok( $token_res->{authorization_details},
+        "small payment is granted by rule" );
+};
+
+subtest "RP without RAR enabled rejects authorization_details" => sub {
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id             => "rp_norar",
+            authorization_details => $valid_details,
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "RAR-disabled RP returns portal error when details are sent" );
+};
+
+subtest "Request without authorization_details still works" => sub {
+    my $auth_res = authorize(
+        $op, $id,
+        {
+            %base_authorize,
+            client_id => "rp",
+        }
+    );
+    my ($code) = expectRedirection( $auth_res, qr#http://.*code=([^\&]*)# );
+    ok( $code, "Authorization code received without RAR" );
+
+    my $token_res = expectJSON(
+        codeGrant( $op, "rp", $code, "http://rp.com/" )
+    );
+    ok( $token_res->{access_token}, "Access token received" );
+    ok( !$token_res->{authorization_details},
+        "no authorization_details in response when not requested" );
+};
+
+clean_sessions();
+done_testing();
+
+sub op {
+    return LLNG::Manager::Test->new( {
+            ini => {
+                domain                          => 'idp.com',
+                portal                          => 'http://auth.op.com/',
+                authentication                  => 'Demo',
+                userDB                          => 'Same',
+                customPlugins                   => '::Plugins::OIDCRichAuthRequest',
+                issuerDBOpenIDConnectActivation => "1",
+                restSessionServer               => 1,
+
+                # RAR global allowlist
+                oidcServiceAuthorizationDetailsTypes =>
+                  'payment_initiation,account_information',
+
+                oidcRPMetaDataExportedVars => {
+                    rp        => { email => "mail", name => "cn", groups => "groups" },
+                    rp_strict => { email => "mail", name => "cn", groups => "groups" },
+                    rp_norar  => { email => "mail", name => "cn", groups => "groups" },
+                },
+                oidcServiceAllowAuthorizationCodeFlow => 1,
+                oidcServiceAllowOffline               => 1,
+                oidcRPMetaDataOptions                 => {
+                    rp => {
+                        oidcRPMetaDataOptionsDisplayName            => "RP",
+                        oidcRPMetaDataOptionsIDTokenExpiration      => 3600,
+                        oidcRPMetaDataOptionsClientID               => "rp",
+                        oidcRPMetaDataOptionsClientSecret           => "rp",
+                        oidcRPMetaDataOptionsIDTokenSignAlg         => "RS256",
+                        oidcRPMetaDataOptionsBypassConsent          => 1,
+                        oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
+                        oidcRPMetaDataOptionsAccessTokenJWT         => 1,
+                        oidcRPMetaDataOptionsAccessTokenSignAlg     => "RS256",
+                        oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
+                        oidcRPMetaDataOptionsAllowOffline           => 1,
+                        oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
+                        oidcRPMetaDataOptionsAuthorizationDetailsTypes =>
+                          'payment_initiation,account_information',
+                    },
+                    rp_strict => {
+                        oidcRPMetaDataOptionsDisplayName            => "RP Strict",
+                        oidcRPMetaDataOptionsIDTokenExpiration      => 3600,
+                        oidcRPMetaDataOptionsClientID               => "rp_strict",
+                        oidcRPMetaDataOptionsClientSecret           => "rp_strict",
+                        oidcRPMetaDataOptionsIDTokenSignAlg         => "RS256",
+                        oidcRPMetaDataOptionsBypassConsent          => 1,
+                        oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
+                        oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
+                        oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
+                        oidcRPMetaDataOptionsAuthorizationDetailsTypes =>
+                          'payment_initiation',
+                        # Rule: only allow payments up to 50 EUR
+                        oidcRPMetaDataOptionsAuthorizationDetailsRule =>
+                          '$type ne "payment_initiation" or $detail->{instructedAmount}->{amount} <= 50',
+                    },
+                    rp_norar => {
+                        oidcRPMetaDataOptionsDisplayName            => "RP NoRAR",
+                        oidcRPMetaDataOptionsIDTokenExpiration      => 3600,
+                        oidcRPMetaDataOptionsClientID               => "rp_norar",
+                        oidcRPMetaDataOptionsClientSecret           => "rp_norar",
+                        oidcRPMetaDataOptionsIDTokenSignAlg         => "RS256",
+                        oidcRPMetaDataOptionsBypassConsent          => 1,
+                        oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
+                        oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
+                        # RAR disabled
+                    },
+                },
+                oidcServicePrivateKeySig => oidc_key_op_private_sig,
+                oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+            }
+        }
+    );
+}

--- a/plugins/oidc-rar/t/35-OIDC-RAR.t
+++ b/plugins/oidc-rar/t/35-OIDC-RAR.t
@@ -365,9 +365,6 @@ sub op {
                         oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
                         oidcRPMetaDataOptionsAuthorizationDetailsTypes =>
                           'payment_initiation',
-                        # Rule: only allow payments up to 50 EUR
-                        oidcRPMetaDataOptionsAuthorizationDetailsRule =>
-                          '$type ne "payment_initiation" or $detail->{instructedAmount}->{amount} <= 50',
                     },
                     rp_norar => {
                         oidcRPMetaDataOptionsDisplayName            => "RP NoRAR",
@@ -390,9 +387,19 @@ sub op {
                         oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
                         oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
                         oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
+                    },
+                },
+                # Per-RP, per-type Perl rules (oidcRPMetaDataAuthorizationDetailsRules
+                # is a top-level keyTextContainer, like oidcRPMetaDataScopeRules).
+                oidcRPMetaDataAuthorizationDetailsRules => {
+                    rp_strict => {
+                        # Only allow payments up to 50 EUR
+                        payment_initiation =>
+                          '$detail->{instructedAmount}->{amount} <= 50',
+                    },
+                    rp_badrule => {
                         # Syntactically broken Perl: must trigger fail-closed
-                        oidcRPMetaDataOptionsAuthorizationDetailsRule =>
-                          'this is not valid perl ((',
+                        payment_initiation => 'this is not valid perl ((',
                     },
                 },
                 oidcServicePrivateKeySig => oidc_key_op_private_sig,


### PR DESCRIPTION
## Summary

- New plugin `oidc-rar` implementing [RFC 9396 Rich Authorization Requests](https://www.rfc-editor.org/rfc/rfc9396) on the OIDC Provider side.
- Companion 4-line patch to `oidc-par` so `authorization_details` survives the PAR storage round-trip when both plugins are enabled together.

## What `oidc-rar` does

Accepts the `authorization_details` parameter on `/oauth2/authorize`, validates it, persists it through code / refresh / access-token sessions, and surfaces it in:

| Surface | Mechanism |
|---|---|
| `/oauth2/token` JSON response | top-level `authorization_details` field |
| JWT access token | `authorization_details` claim (when AT-as-JWT is enabled on the RP) |
| `/oauth2/introspect` response | top-level `authorization_details` field |
| `/.well-known/openid-configuration` | `authorization_details_types_supported` array |
| Refresh token grant | preserved across refreshes |
| Consent template | `RAR_DETAILS` (pretty-printed) injected into `oidcConsents` / `oidcGiveConsent` via the `sendHtml` hook |

## Authorization model — 3 layers

1. **Type allowlist** — `oidcServiceAuthorizationDetailsTypes` ∩ `oidcRPMetaDataOptionsAuthorizationDetailsTypes`.
2. **Per-RP Perl rule** — `oidcRPMetaDataOptionsAuthorizationDetailsRule`, compiled with the same `buildSub` / `Safe::reval` plumbing used by `oidcRPMetaDataScopeRules`, evaluated against `$req->userData` plus magic `$type` and `$detail` (the full hashref). Lets ops write rules like `$type ne 'payment_initiation' or $detail->{instructedAmount}{amount} <= 1000`.
3. **User consent** — operator's consent template renders `RAR_DETAILS`.

Failures at any layer return a portal error (V1 limitation; RFC-compliant `error=invalid_authorization_details` redirect to the RP is documented as a follow-up).

## Hook wiring (11 hooks)

`oidcGotRequest`, `oidcGenerateCode`, **`oidcGotTokenRequest`** (used to repopulate `$req->data` from the code or refresh session at `/oauth2/token`, since the back-channel call has no shared state with the authorize phase), `oidcGenerateRefreshToken`, `oidcGotOnlineRefresh`, `oidcGotOfflineRefresh`, `oidcGenerateAccessToken` (also calls `updateToken` so introspection sees the details on the AT session), `oidcGenerateTokenResponse`, `oidcGenerateIntrospectionResponse`, `oidcGenerateMetadata`, `sendHtml`.

Requires LLNG >= 2.23.0 (for `oidcGotTokenRequest` and the broader hook surface).

## oidc-par patch

`authorization_details` is added to the parameter allowlists in both `pushAuthRequest` and `resolvePushedRequest`. Without this, RAR + PAR combined would silently drop the parameter.

## Out of scope (documented in README)

- Token-endpoint scope-down (RFC 9396 §3, optional).
- Type-specific structural validation (only generic shape is checked).
- Client-side support (LLNG-as-RP).
- Dynamic registration honoring `authorization_details_types`.
- RFC-compliant redirect-to-RP error responses.

## Test plan

- [x] `t/35-OIDC-RAR.t` — 19 subtests, all green: discovery advertise, token-response echo, JWT claim, introspection, refresh-token preservation, allowlist rejection, malformed JSON, detail without `type`, Perl rule reject/grant, RP without RAR enabled, no-RAR baseline.
- [x] `t/32-OIDC-PAR.t` — existing 18 subtests still green + new "PAR forwards authorization_details (RFC 9396)" subtest.
- [x] `t/32-OIDC-PAR-client.t`, `t/32-OIDC-PAR-private-key-jwt.t` — unchanged, still green.

Run via the repo's MCP toolchain:
```
mcp__llng-plugins__test plugin=oidc-rar
mcp__llng-plugins__test plugin=oidc-par
```

## Versioning

No version bump in this PR — the repo uses lockstep versioning at release time (cf. CHANGELOG v0.1.20). New plugin starts at `0.1.0` per convention.