### PR TITLE
Add oidc-grant-management plugin (FAPI Grant Management API)

### DIFF
--- a/plugins/oidc-grant-management/README.md
+++ b/plugins/oidc-grant-management/README.md
@@ -2,18 +2,77 @@
 
 This plugin implements the **OpenID Foundation [FAPI Grant Management for OAuth 2.0](https://openid.net/specs/fapi-grant-management.html)** specification on the LemonLDAP::NG OIDC Provider side.
 
-It introduces *grants* as durable first-class records, distinct from tokens: a grant captures the cumulative set of scopes (and `authorization_details` if `oidc-rar` is also active) authorized for a `(client, user)` couple, persists across token rotations, and can be queried or revoked through a RESTful API independently of any individual token's lifecycle.
+It introduces _grants_ as durable first-class records, distinct from tokens: a grant captures the cumulative set of scopes (and `authorization_details` if `oidc-rar` is also active) authorized for a `(client, user)` couple, persists across token rotations, and can be queried or revoked through a RESTful API independently of any individual token's lifecycle.
 
 ## Why grants?
 
-Plain OAuth 2.0 has access tokens (short-lived) and refresh tokens (medium-lived) but **nothing durable that materializes the user's authorization**. Apps that need to:
+Plain OAuth 2.0 has two kinds of artifacts: access tokens (minutes) and refresh tokens (hours to weeks). Neither _materializes the underlying authorization_. There is no standard way to ask the AS "what did this user authorize this client to do, and when?", or to "remove this app's access" in one go: token revocation works token by token, and a refresh token chain that's been rotated is gone — but the _intent_ it represented is invisible to everyone.
 
-- track "what did this user authorize this client to do, and when?";
-- let the user revoke an entire authorization in one operation, not token by token;
-- ask the user to *renew* an authorization (PSD2 §50: 90-day refresh) without restarting from scratch;
-- *add* permissions to an existing authorization (e.g., the user adds a second bank account to a fintech app);
+A **grant** is the missing first-class record. One grant per `(client, user)` (per consent), durable, queryable, modifiable, revocable. Tokens become tags on the grant, not the authorization itself.
 
-…all need a notion of grant. This plugin adds it.
+### Concrete scenarios
+
+#### 1. Open banking (the canonical use case)
+
+PSD2 RTS Article 10(b) caps "Account Information Service" consent durations to 90 days — every 90 days the user must reaffirm. Without grant management, the fintech app drives the user back through a full authorize flow with all the consent UI: scope selection, account picker, etc. With grant management it sends:
+
+```
+GET /oauth2/authorize?
+    grant_management_action=update&
+    grant_id=<the-existing-id>&
+    scope=accounts+balances&
+    ...
+```
+
+The OP loads the existing grant, asks the user only "extend until next quarter?", and the fintech keeps working with the same `grant_id`. No data loss on the fintech side (account selections stay tied to the same grant), no UX trauma for the user.
+
+#### 2. Add an account / scope to an active authorization
+
+A user authorized a fintech to read their checking account. A month later they buy a stock and want the fintech to read their broker account too. Without grant management: full re-authorize. With:
+
+```
+GET /oauth2/authorize?
+    grant_management_action=update&
+    grant_id=<existing>&
+    authorization_details=[{"type":"account_information","accounts":["broker-789"]}]
+```
+
+The OP shows a delta consent ("add broker-789?"), the grant grows. Same id everywhere.
+
+#### 3. "Disconnect this app" in user-facing dashboards
+
+`Settings → Connected Apps → Acme Bank → Disconnect`. With plain OAuth, the operator either runs N revocation calls (one per outstanding refresh token) or relies on cookie-based session bookkeeping. With grant management the dashboard issues a single `DELETE /oauth2/grants/<id>` and is done — and the AS can then proactively iterate tokens to invalidate them on the next request (best-effort in v1; see Limitations).
+
+#### 4. "Show me what these apps have access to"
+
+Same dashboard. To render the "Acme Bank can read: account-1, account-2, balances since 2026-01-15" panel, the operator hits `GET /oauth2/grants/<id>` and gets a structured JSON. No need to invent a separate management API.
+
+#### 5. Multiple grants for the same RP
+
+Some setups want one grant per device or per use case. PSD2 explicitly allows it: the same fintech holds one `grant_id` for "balances" (90-day TTL) and another for "payments" (one-shot or short-lived), revocable independently. This plugin supports it: each `grant_management_action=create` mints a fresh grant. The client tracks them by id.
+
+#### 6. Compliance and audit
+
+A grant carries `created_at`, `last_used_at`, the cumulative scope set, the cumulative `authorization_details`. That's exactly the audit trail PSD3, DORA, and most banking regulators want. The plugin doesn't ship a dashboard, but the data is there for one.
+
+### Why refresh tokens aren't enough
+
+| Need                                       | Refresh token                                                                                | Grant                                                          |
+| ------------------------------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
+| "What scopes did this user authorize?"     | Stored implicitly, not queryable                                                             | First-class field                                              |
+| Revoke an authorization                    | Revoke the RT — but ATs issued from it stay valid until expiration                           | Same caveat for v1 (see Limitations), but the intent is captured |
+| Survive RT rotation                        | RT id changes on every rotation; the "authorization" loses identity                          | `grant_id` is stable                                           |
+| Two devices, same auth                     | Two unrelated RT chains; no shared identity                                                  | Optional: same `grant_id` across both, or two grants           |
+| Add/remove permissions mid-life            | Not possible — must re-authorize from scratch                                                | `update` / `replace`                                           |
+| Inspect from the user's account dashboard  | No standard endpoint                                                                         | `GET /oauth2/grants/{id}`                                      |
+
+### Where this matters today
+
+- **PSD2 / open banking** — RTS Article 10 essentially forces grant-management thinking; the FAPI WG wrote this spec largely with PSD2 in mind.
+- **Open insurance, open energy, open data** — all importing the PSD2 model.
+- **PSD3** (2026 draft) — raises the consent expiry to 180 days and explicitly references grant management as the renewal mechanism.
+- **Healthcare / HEART** — similar consent-driven flows with stricter audit requirements.
+- **Enterprise B2B** — multi-tenant SaaS where a client app holds different grants per customer tenant; admins want a "kill switch" per tenant without breaking the others.
 
 ## What it does
 
@@ -21,11 +80,11 @@ Three things, with a **`grant_id`** that ties them together:
 
 ### 1. `grant_management_action` parameter on `/oauth2/authorize`
 
-| Action      | Effect                                                                                                                                  |
-| ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `create`    | (default if RP mode allows) Mint a fresh grant. The new `grant_id` is returned in the token response.                                   |
-| `update`    | Load the grant pointed at by the `grant_id` request parameter and **add** the requested scopes/details. Same `grant_id` is returned.    |
-| `replace`   | Load the grant and **replace** its scope set with the newly requested one. Same `grant_id` is returned.                                 |
+| Action    | Effect                                                                                                                               |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `create`  | (default if RP mode allows) Mint a fresh grant. The new `grant_id` is returned in the token response.                                |
+| `update`  | Load the grant pointed at by the `grant_id` request parameter and **add** the requested scopes/details. Same `grant_id` is returned. |
+| `replace` | Load the grant and **replace** its scope set with the newly requested one. Same `grant_id` is returned.                              |
 
 ### 2. `grant_id` field
 
@@ -52,22 +111,22 @@ With `lemonldap-ng-store` (LLNG ≥ 2.24.0):
 sudo lemonldap-ng-store install oidc-grant-management
 ```
 
-Manually: copy `lib/` and `manager-overrides/`, add `::Plugins::OIDCGrantManagement` to *Custom plugins*, run `llng-build-manager-files`.
+Manually: copy `lib/` and `manager-overrides/`, add `::Plugins::OIDCGrantManagement` to _Custom plugins_, run `llng-build-manager-files`.
 
 ## Configuration
 
-In **Manager → *OpenID Connect Service*** :
+In **Manager → _OpenID Connect Service_** :
 
-| Parameter                                | Default     | Description                                                                                  |
-| ---------------------------------------- | ----------- | -------------------------------------------------------------------------------------------- |
-| `oidcServiceMetaDataGrantManagementURI`  | `grants`    | Endpoint path component. Final URL is `/<oidc-path>/<this>/{grant_id}`.                     |
-| `oidcServiceGrantExpiration`             | `7776000`   | Grant TTL in seconds. Default 90 days, aligned with PSD2.                                    |
+| Parameter                               | Default   | Description                                                             |
+| --------------------------------------- | --------- | ----------------------------------------------------------------------- |
+| `oidcServiceMetaDataGrantManagementURI` | `grants`  | Endpoint path component. Final URL is `/<oidc-path>/<this>/{grant_id}`. |
+| `oidcServiceGrantExpiration`            | `7776000` | Grant TTL in seconds. Default 90 days, aligned with PSD2.               |
 
-In **Manager → *OIDC Relying Parties* → `<rp>` → *Options* → *Security*** :
+In **Manager → _OIDC Relying Parties_ → `<rp>` → _Options_ → _Security_** :
 
-| Parameter                              | Values                          | Description                                                                                            |
-| -------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| `oidcRPMetaDataOptionsGrantManagement` | `""` / `allowed` / `required`   | Disabled / accept `grant_management_action` if the client sends it / reject authorize without action. |
+| Parameter                              | Values                        | Description                                                                                           |
+| -------------------------------------- | ----------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `oidcRPMetaDataOptionsGrantManagement` | `""` / `allowed` / `required` | Disabled / accept `grant_management_action` if the client sends it / reject authorize without action. |
 
 ## Discovery
 

--- a/plugins/oidc-grant-management/README.md
+++ b/plugins/oidc-grant-management/README.md
@@ -1,0 +1,114 @@
+# OIDC Grant Management — FAPI Grant Management API
+
+This plugin implements the **OpenID Foundation [FAPI Grant Management for OAuth 2.0](https://openid.net/specs/fapi-grant-management.html)** specification on the LemonLDAP::NG OIDC Provider side.
+
+It introduces *grants* as durable first-class records, distinct from tokens: a grant captures the cumulative set of scopes (and `authorization_details` if `oidc-rar` is also active) authorized for a `(client, user)` couple, persists across token rotations, and can be queried or revoked through a RESTful API independently of any individual token's lifecycle.
+
+## Why grants?
+
+Plain OAuth 2.0 has access tokens (short-lived) and refresh tokens (medium-lived) but **nothing durable that materializes the user's authorization**. Apps that need to:
+
+- track "what did this user authorize this client to do, and when?";
+- let the user revoke an entire authorization in one operation, not token by token;
+- ask the user to *renew* an authorization (PSD2 §50: 90-day refresh) without restarting from scratch;
+- *add* permissions to an existing authorization (e.g., the user adds a second bank account to a fintech app);
+
+…all need a notion of grant. This plugin adds it.
+
+## What it does
+
+Three things, with a **`grant_id`** that ties them together:
+
+### 1. `grant_management_action` parameter on `/oauth2/authorize`
+
+| Action      | Effect                                                                                                                                  |
+| ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `create`    | (default if RP mode allows) Mint a fresh grant. The new `grant_id` is returned in the token response.                                   |
+| `update`    | Load the grant pointed at by the `grant_id` request parameter and **add** the requested scopes/details. Same `grant_id` is returned.    |
+| `replace`   | Load the grant and **replace** its scope set with the newly requested one. Same `grant_id` is returned.                                 |
+
+### 2. `grant_id` field
+
+Surfaces in three places:
+
+- **Token response JSON** (always, when an action was provided);
+- **JWT access token claim** (`grant_id`);
+- **Introspection response**.
+
+### 3. RESTful endpoint
+
+```
+GET    /oauth2/grants/{grant_id}    →  200 JSON describing the grant
+DELETE /oauth2/grants/{grant_id}    →  204 No Content; grant revoked
+```
+
+Authenticated as the OAuth client that owns the grant (`Authorization: Basic` or any of the standard token-endpoint client auth methods). A client cannot read or revoke a grant that doesn't belong to it (returns 403).
+
+## Installation
+
+With `lemonldap-ng-store` (LLNG ≥ 2.24.0):
+
+```bash
+sudo lemonldap-ng-store install oidc-grant-management
+```
+
+Manually: copy `lib/` and `manager-overrides/`, add `::Plugins::OIDCGrantManagement` to *Custom plugins*, run `llng-build-manager-files`.
+
+## Configuration
+
+In **Manager → *OpenID Connect Service*** :
+
+| Parameter                                | Default     | Description                                                                                  |
+| ---------------------------------------- | ----------- | -------------------------------------------------------------------------------------------- |
+| `oidcServiceMetaDataGrantManagementURI`  | `grants`    | Endpoint path component. Final URL is `/<oidc-path>/<this>/{grant_id}`.                     |
+| `oidcServiceGrantExpiration`             | `7776000`   | Grant TTL in seconds. Default 90 days, aligned with PSD2.                                    |
+
+In **Manager → *OIDC Relying Parties* → `<rp>` → *Options* → *Security*** :
+
+| Parameter                              | Values                          | Description                                                                                            |
+| -------------------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `oidcRPMetaDataOptionsGrantManagement` | `""` / `allowed` / `required`   | Disabled / accept `grant_management_action` if the client sends it / reject authorize without action. |
+
+## Discovery
+
+When at least one RP has Grant Management enabled, the plugin advertises:
+
+```json
+{
+  "grant_management_endpoint": "https://op.example.com/oauth2/grants",
+  "grant_management_actions_supported": ["create", "replace", "update"]
+}
+```
+
+## Limitations (v1)
+
+- **Token cascade revocation is best-effort.** `DELETE /oauth2/grants/{id}` removes the grant session, but already-issued access tokens stay valid until they expire. Operators wanting hard cascade can shorten access-token TTLs or pair this plugin with a custom userinfo/introspection hook that re-checks the grant. A hooked re-check feature can land in v2.
+- **`merge` action not supported.** RFC says it's optional and the semantics are ambiguous.
+- **No native consent-screen integration.** When an `update` or `replace` action arrives with `BypassConsent=0`, the user sees the standard consent UI, not a delta-aware one. Operators wanting a delta UI need a custom template.
+- **Grant ownership tied to the RP confKey.** A client renamed in the manager loses access to grants held under its old name. Don't rename RPs in flight.
+
+## Hook map
+
+| Hook                                | Role                                                                                                                  |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `oidcGotRequest`                    | Parse `grant_management_action` + `grant_id`, validate against the per-RP mode, stash on `$req->data`                 |
+| `oidcGenerateCode`                  | Materialize the grant (mint or update/replace) so its id is known before any AT is built; persist on the code session |
+| `oidcGotTokenRequest`               | At /token, restore grant context from the code or refresh session                                                     |
+| `oidcGenerateRefreshToken`          | Carry the grant context onto refresh sessions (survives rotation)                                                     |
+| `oidcGenerateAccessToken`           | Add `grant_id` claim to JWT AT and patch the AT session for introspection                                             |
+| `oidcGenerateTokenResponse`         | Echo `grant_id` in the JSON token response                                                                            |
+| `oidcGenerateIntrospectionResponse` | Surface `grant_id` in introspection                                                                                   |
+| `oidcGenerateMetadata`              | Advertise `grant_management_endpoint` + `_actions_supported`                                                          |
+
+The RESTful endpoint is registered in `init()` via `addUnauthRoute` with the `:grant_id` path-capture syntax.
+
+## Combining with `oidc-rar`
+
+If `oidc-rar` is also loaded, the grant carries `authorization_details` alongside the scope set: GET on the grant returns the cumulative `authorization_details`, and `update`/`replace` extends/replaces them the same way they do for scopes.
+
+## See also
+
+- [FAPI Grant Management for OAuth 2.0](https://openid.net/specs/fapi-grant-management.html)
+- [`oidc-rar`](../oidc-rar/) — Rich Authorization Requests (RFC 9396)
+- [`oidc-resource-indicators`](../oidc-resource-indicators/) — Resource Indicators (RFC 8707)
+- [`oidc-acr-claims`](../oidc-acr-claims/) — `acr` + `auth_time` on JWT access tokens

--- a/plugins/oidc-grant-management/README.md
+++ b/plugins/oidc-grant-management/README.md
@@ -57,14 +57,14 @@ A grant carries `created_at`, `last_used_at`, the cumulative scope set, the cumu
 
 ### Why refresh tokens aren't enough
 
-| Need                                       | Refresh token                                                                                | Grant                                                          |
-| ------------------------------------------ | -------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
-| "What scopes did this user authorize?"     | Stored implicitly, not queryable                                                             | First-class field                                              |
-| Revoke an authorization                    | Revoke the RT — but ATs issued from it stay valid until expiration                           | Same caveat for v1 (see Limitations), but the intent is captured |
-| Survive RT rotation                        | RT id changes on every rotation; the "authorization" loses identity                          | `grant_id` is stable                                           |
-| Two devices, same auth                     | Two unrelated RT chains; no shared identity                                                  | Optional: same `grant_id` across both, or two grants           |
-| Add/remove permissions mid-life            | Not possible — must re-authorize from scratch                                                | `update` / `replace`                                           |
-| Inspect from the user's account dashboard  | No standard endpoint                                                                         | `GET /oauth2/grants/{id}`                                      |
+| Need                                      | Refresh token                                                       | Grant                                                            |
+| ----------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| "What scopes did this user authorize?"    | Stored implicitly, not queryable                                    | First-class field                                                |
+| Revoke an authorization                   | Revoke the RT — but ATs issued from it stay valid until expiration  | Same caveat for v1 (see Limitations), but the intent is captured |
+| Survive RT rotation                       | RT id changes on every rotation; the "authorization" loses identity | `grant_id` is stable                                             |
+| Two devices, same auth                    | Two unrelated RT chains; no shared identity                         | Optional: same `grant_id` across both, or two grants             |
+| Add/remove permissions mid-life           | Not possible — must re-authorize from scratch                       | `update` / `replace`                                             |
+| Inspect from the user's account dashboard | No standard endpoint                                                | `GET /oauth2/grants/{id}`                                        |
 
 ### Where this matters today
 
@@ -82,7 +82,7 @@ Three things, with a **`grant_id`** that ties them together:
 
 | Action    | Effect                                                                                                                               |
 | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| `create`  | (default if RP mode allows) Mint a fresh grant. The new `grant_id` is returned in the token response.                                |
+| `create`  | Mint a fresh grant. The new `grant_id` is returned in the token response. (Action is opt-in: an authorize call without `grant_management_action` does NOT create a grant — the FAPI draft has gone back and forth on whether `create` is implicit; this plugin requires it explicitly.) |
 | `update`  | Load the grant pointed at by the `grant_id` request parameter and **add** the requested scopes/details. Same `grant_id` is returned. |
 | `replace` | Load the grant and **replace** its scope set with the newly requested one. Same `grant_id` is returned.                              |
 
@@ -144,7 +144,7 @@ When at least one RP has Grant Management enabled, the plugin advertises:
 - **Token cascade revocation is best-effort.** `DELETE /oauth2/grants/{id}` removes the grant session, but already-issued access tokens stay valid until they expire. Operators wanting hard cascade can shorten access-token TTLs or pair this plugin with a custom userinfo/introspection hook that re-checks the grant. A hooked re-check feature can land in v2.
 - **`merge` action not supported.** RFC says it's optional and the semantics are ambiguous.
 - **No native consent-screen integration.** When an `update` or `replace` action arrives with `BypassConsent=0`, the user sees the standard consent UI, not a delta-aware one. Operators wanting a delta UI need a custom template.
-- **Grant ownership tied to the RP confKey.** A client renamed in the manager loses access to grants held under its old name. Don't rename RPs in flight.
+- **Grant ownership tied to `client_id`, not the RP confKey.** As long as the OAuth `client_id` stays the same, renaming the RP in the manager (changing its confKey) preserves access. Changing a client's `client_id` is what loses access — that's by design (it's a different client).
 
 ## Hook map
 
@@ -163,7 +163,13 @@ The RESTful endpoint is registered in `init()` via `addUnauthRoute` with the `:g
 
 ## Combining with `oidc-rar`
 
-If `oidc-rar` is also loaded, the grant carries `authorization_details` alongside the scope set: GET on the grant returns the cumulative `authorization_details`, and `update`/`replace` extends/replaces them the same way they do for scopes.
+If `oidc-rar` is also loaded, the grant carries `authorization_details` alongside the scope set. Both follow the same per-action semantics:
+
+- **`create`** — the grant is born with the request's `authorization_details`.
+- **`update`** — the new entries are unioned into the existing list, deduped by structural (JSON-canonical) equality. So a fintech adding a second account doesn't lose the first one.
+- **`replace`** — the existing list is replaced by the request's entries verbatim.
+
+GET on the grant returns the cumulative `authorization_details`.
 
 ## See also
 

--- a/plugins/oidc-grant-management/lib/Lemonldap/NG/Portal/Plugins/OIDCGrantManagement.pm
+++ b/plugins/oidc-grant-management/lib/Lemonldap/NG/Portal/Plugins/OIDCGrantManagement.pm
@@ -95,8 +95,11 @@ sub parseGrantManagementParam {
       || $req->param('grant_id');
 
     # If the RP requires Grant Management, every authorize MUST carry an
-    # action. Default to `create` is acceptable for `allowed` mode but not
-    # for `required` (per FAPI spec §3.1).
+    # action. In `allowed` mode the action is strictly opt-in: requests
+    # without `grant_management_action` produce no `grant_id`. (The FAPI
+    # draft has gone back and forth on whether `create` is the implicit
+    # default; this plugin currently treats absence as "no grant", which
+    # is also what the test suite asserts.)
     if ( $mode eq 'required' and not $action ) {
         $self->logger->error(
             "OIDCGrantManagement: RP `$rp` requires grant_management_action "
@@ -196,27 +199,46 @@ sub materializeGrantAndStoreOnCode {
             return PE_ERROR;
         };
 
+        # Subject check: a client presenting a stolen `grant_id` must NOT
+        # be able to update/replace another user's grant. The user is
+        # authenticated by the time oidcGenerateCode fires, so we can
+        # compare the grant owner against the current session.
+        my $grant_sub = $grant->data->{sub} // '';
+        if ( length $grant_sub and $grant_sub ne $sub ) {
+            $self->logger->error(
+                "OIDCGrantManagement: grant `$grant_id` is owned by a "
+                  . "different subject (got `$sub`, expected `$grant_sub`)"
+            );
+            return PE_ERROR;
+        }
+
         my %merged_scope =
           map { $_ => 1 } split /\s+/, $grant->data->{scope} || '';
 
+        # `authorization_details` (RFC 9396, set by oidc-rar when active)
+        # follows the same semantics as `scope`:
+        #   - update  => union of existing + new entries (deduped by `type`)
+        #   - replace => entries from the current request only
+        my $existing_rar = $grant->data->{authorization_details};
+        my $new_rar;
         if ( $action eq 'update' ) {
             $merged_scope{$_} = 1 for split /\s+/, $scope;
+            $new_rar = _mergeRar( $existing_rar, $rar );
         }
         elsif ( $action eq 'replace' ) {
             %merged_scope = map { $_ => 1 } split /\s+/, $scope;
+            $new_rar = $rar;
         }
-        $self->oidc->updateToken(
-            $grant_id,
-            {
+
+        $grant->update( {
                 scope => join( ' ', sort keys %merged_scope ),
                 (
-                    defined $rar
-                    ? ( authorization_details => $rar )
+                    defined $new_rar
+                    ? ( authorization_details => $new_rar )
                     : ()
                 ),
                 last_used_at => time,
-            }
-        );
+        } );
     }
 
     $ctx->{grant_id} = $grant_id;
@@ -396,6 +418,27 @@ sub _loadGrant {
     my ( $self, $grant_id ) = @_;
     return undef unless $grant_id;
     return $self->oidc->getOpenIDConnectSession( $grant_id, &SESSION_KIND );
+}
+
+# Union of two `authorization_details` arrays, deduped by structural
+# equality (cheap JSON-canonical comparison). Used by the `update`
+# action so a fintech adding a second account doesn't lose the first one.
+sub _mergeRar {
+    my ( $existing, $new ) = @_;
+    return $existing unless defined $new and ref($new) eq 'ARRAY';
+    return $new
+      unless defined $existing
+      and ref($existing) eq 'ARRAY'
+      and @$existing;
+
+    my %seen;
+    my @out;
+    for my $entry ( @$existing, @$new ) {
+        my $key = JSON->new->canonical->encode($entry);
+        next if $seen{$key}++;
+        push @out, $entry;
+    }
+    return \@out;
 }
 
 sub _jsonError {

--- a/plugins/oidc-grant-management/lib/Lemonldap/NG/Portal/Plugins/OIDCGrantManagement.pm
+++ b/plugins/oidc-grant-management/lib/Lemonldap/NG/Portal/Plugins/OIDCGrantManagement.pm
@@ -1,0 +1,413 @@
+package Lemonldap::NG::Portal::Plugins::OIDCGrantManagement;
+
+# FAPI Grant Management for OAuth 2.0
+# https://openid.net/specs/fapi-grant-management.html
+#
+# Adds:
+#   * `grant_management_action` parameter on /oauth2/authorize
+#     (`create` / `update` / `replace`)
+#   * `grant_id` field in token responses
+#   * RESTful endpoint at /oauth2/{grant_management_uri}/{grant_id}
+#     - GET    => return JSON description of the grant
+#     - DELETE => revoke the grant
+#   * Discovery fields `grant_management_actions_supported` and
+#     `grant_management_endpoint`
+#
+# Grants are stored as a dedicated session kind. The grant id is the LLNG
+# session id, so client-presented grant_ids resolve straight to a session
+# lookup with no search-by-attribute.
+#
+# Token cascade revocation on DELETE is BEST-EFFORT in this v1: only the
+# grant session is removed. Already-issued access tokens stay valid until
+# their TTL expires. Operators wanting hard revocation can shorten the AT
+# TTL or pair the plugin with a custom userinfo/introspection hook that
+# re-checks the grant.
+
+use strict;
+use Mouse;
+use JSON;
+use Lemonldap::NG::Portal::Main::Constants qw(
+  PE_OK
+  PE_ERROR
+  PE_SENDRESPONSE
+);
+
+our $VERSION = '2.24.0';
+
+extends 'Lemonldap::NG::Portal::Lib::OIDCPlugin';
+
+use constant SESSION_KIND     => 'OIDCGrant';
+use constant DATA_KEY         => '_grant_ctx';
+use constant SUPPORTED_ACTIONS => [qw(create update replace)];
+
+use constant hook => {
+    oidcGotRequest                    => 'parseGrantManagementParam',
+    oidcGenerateCode                  => 'materializeGrantAndStoreOnCode',
+    oidcGotTokenRequest               => 'restoreOnTokenEndpoint',
+    oidcGenerateRefreshToken          => 'storeOnRefresh',
+    oidcGenerateTokenResponse         => 'echoGrantId',
+    oidcGenerateAccessToken           => 'addGrantIdToAccessToken',
+    oidcGenerateIntrospectionResponse => 'addGrantIdToIntrospection',
+    oidcGenerateMetadata              => 'advertiseEndpoint',
+};
+
+sub init {
+    my ($self) = @_;
+    return unless $self->SUPER::init;
+
+    my $uri = $self->conf->{oidcServiceMetaDataGrantManagementURI}
+      || 'grants';
+
+    # Register the RESTful endpoint at /<oidc-path>/<uri>/<grant_id>.
+    # The PSGI router supports `:name` to capture path components into
+    # request params (cf. Lemonldap::NG::Common::PSGI::Router doc).
+    $self->addUnauthRoute(
+        $self->oidc->path => {
+            $uri => {
+                ':grant_id' => 'handleGrantEndpoint',
+            }
+        },
+        [ 'GET', 'DELETE' ],
+    );
+    return 1;
+}
+
+# ---------------------------------------------------------------------------
+# Hooks on /oauth2/authorize
+
+# Hook: oidcGotRequest
+# Parse `grant_management_action` and `grant_id` from the request, validate
+# against the per-RP mode, and stash on $req->data->{DATA_KEY} so the rest
+# of the flow can act on it.
+sub parseGrantManagementParam {
+    my ( $self, $req, $oidc_request ) = @_;
+
+    my $client_id = $oidc_request->{client_id} or return PE_OK;
+    my $rp = $self->oidc->getRP($client_id) or return PE_OK;
+    my $mode = $self->oidc->rpOptions->{$rp}
+      ->{oidcRPMetaDataOptionsGrantManagement} // '';
+
+    my $action =
+         $oidc_request->{grant_management_action}
+      || $req->param('grant_management_action');
+    my $grant_id =
+         $oidc_request->{grant_id}
+      || $req->param('grant_id');
+
+    # If the RP requires Grant Management, every authorize MUST carry an
+    # action. Default to `create` is acceptable for `allowed` mode but not
+    # for `required` (per FAPI spec §3.1).
+    if ( $mode eq 'required' and not $action ) {
+        $self->logger->error(
+            "OIDCGrantManagement: RP `$rp` requires grant_management_action "
+              . "and the request did not provide one" );
+        return PE_ERROR;
+    }
+
+    return PE_OK unless $mode eq 'allowed' or $mode eq 'required';
+    return PE_OK unless $action;
+
+    unless ( grep { $_ eq $action } @{ &SUPPORTED_ACTIONS } ) {
+        $self->logger->error(
+            "OIDCGrantManagement: unsupported grant_management_action "
+              . "`$action` (only "
+              . join( '/', @{ &SUPPORTED_ACTIONS } )
+              . " are supported)" );
+        return PE_ERROR;
+    }
+
+    if ( $action ne 'create' ) {
+        unless ($grant_id) {
+            $self->logger->error(
+                "OIDCGrantManagement: action `$action` requires grant_id" );
+            return PE_ERROR;
+        }
+        my $grant = $self->_loadGrant($grant_id);
+        unless ($grant) {
+            $self->logger->error(
+                "OIDCGrantManagement: grant `$grant_id` not found");
+            return PE_ERROR;
+        }
+        if ( $grant->data->{client_id} ne
+            ( $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsClientID}
+                || '' ) )
+        {
+            $self->logger->error(
+                "OIDCGrantManagement: grant `$grant_id` belongs to a "
+                  . "different client" );
+            return PE_ERROR;
+        }
+    }
+
+    $req->data->{ &DATA_KEY } = {
+        action   => $action,
+        grant_id => $grant_id,
+        rp       => $rp,
+    };
+    return PE_OK;
+}
+
+# Hook: oidcGenerateCode
+# Materialize the grant NOW (during /authorize) so the grant_id is known
+# before any access token is built. For action=create or default, mint a
+# fresh session whose id IS the grant_id. For update/replace, merge the
+# requested scope/details into the existing grant. Persist the resulting
+# grant_id on the code session so the back-channel /oauth2/token call can
+# read it.
+sub materializeGrantAndStoreOnCode {
+    my ( $self, $req, $oidc_request, $rp, $code_payload ) = @_;
+    my $ctx = $req->data->{ &DATA_KEY } or return PE_OK;
+
+    my $action    = $ctx->{action};
+    my $grant_id  = $ctx->{grant_id};
+    my $client_id =
+      $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsClientID};
+    my $sub =
+         $req->sessionInfo->{ $self->conf->{whatToTrace} }
+      || $req->userData->{ $self->conf->{whatToTrace} }
+      || '';
+    my $scope = $code_payload->{scope} || '';
+    my $rar   = $req->data->{_rar_details};   # set by oidc-rar if loaded
+    my $ttl = $self->conf->{oidcServiceGrantExpiration} || 7776000;
+
+    if ( $action eq 'create' ) {
+        my $session = $self->oidc->getOpenIDConnectSession(
+            undef,
+            &SESSION_KIND,
+            ttl  => $ttl,
+            info => {
+                rp                    => $rp,
+                client_id             => $client_id,
+                sub                   => $sub,
+                scope                 => $scope,
+                authorization_details => $rar,
+                created_at            => time,
+                last_used_at          => time,
+            }
+        );
+        return PE_OK unless $session;
+        $grant_id = $session->id;
+    }
+    elsif ($grant_id) {
+        my $grant = $self->_loadGrant($grant_id) or do {
+            $self->logger->error(
+                "OIDCGrantManagement: grant `$grant_id` vanished between "
+                  . "parse and code generation" );
+            return PE_ERROR;
+        };
+
+        my %merged_scope =
+          map { $_ => 1 } split /\s+/, $grant->data->{scope} || '';
+
+        if ( $action eq 'update' ) {
+            $merged_scope{$_} = 1 for split /\s+/, $scope;
+        }
+        elsif ( $action eq 'replace' ) {
+            %merged_scope = map { $_ => 1 } split /\s+/, $scope;
+        }
+        $self->oidc->updateToken(
+            $grant_id,
+            {
+                scope => join( ' ', sort keys %merged_scope ),
+                (
+                    defined $rar
+                    ? ( authorization_details => $rar )
+                    : ()
+                ),
+                last_used_at => time,
+            }
+        );
+    }
+
+    $ctx->{grant_id} = $grant_id;
+    $code_payload->{ &DATA_KEY } = $ctx;
+    return PE_OK;
+}
+
+# ---------------------------------------------------------------------------
+# Hooks on /oauth2/token
+
+# Hook: oidcGotTokenRequest
+# Restore grant context from code or refresh session into $req->data so the
+# response-building hooks below can act on it.
+sub restoreOnTokenEndpoint {
+    my ( $self, $req, $rp, $grant_type ) = @_;
+
+    if ( $grant_type eq 'authorization_code' ) {
+        my $code = $req->param('code') or return PE_OK;
+        my $cs = $self->oidc->getAuthorizationCode($code) or return PE_OK;
+        if ( my $ctx = $cs->data->{ &DATA_KEY } ) {
+            $req->data->{ &DATA_KEY } = $ctx;
+        }
+    }
+    elsif ( $grant_type eq 'refresh_token' ) {
+        my $rt = $req->param('refresh_token') or return PE_OK;
+        my $rs = $self->oidc->getRefreshToken($rt) or return PE_OK;
+        if ( my $ctx = $rs->data->{ &DATA_KEY } ) {
+            $req->data->{ &DATA_KEY } = $ctx;
+        }
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateRefreshToken
+# Carry the grant context onto refresh sessions so it survives rotation.
+sub storeOnRefresh {
+    my ( $self, $req, $refresh_info, $rp, $offline ) = @_;
+    my $ctx = $req->data->{ &DATA_KEY } or return PE_OK;
+    $refresh_info->{ &DATA_KEY } = $ctx;
+    return PE_OK;
+}
+
+# Hook: oidcGenerateTokenResponse
+# The grant has already been materialized at /authorize time
+# (materializeGrantAndStoreOnCode). All this hook does is echo grant_id
+# back to the client in the JSON token response.
+sub echoGrantId {
+    my ( $self, $req, $rp, $tokensResponse, $oidcSession, $userSession,
+        $grant_type )
+      = @_;
+    my $ctx = $req->data->{ &DATA_KEY } || $oidcSession->{ &DATA_KEY }
+      or return PE_OK;
+    my $grant_id = $ctx->{grant_id} or return PE_OK;
+    $tokensResponse->{grant_id} = $grant_id;
+    return PE_OK;
+}
+
+# Hook: oidcGenerateAccessToken
+# Add the `grant_id` claim to the JWT access token. Also patches the AT
+# session post-creation (via updateToken) so introspection can surface it.
+sub addGrantIdToAccessToken {
+    my ( $self, $req, $payload, $rp, $extra_headers ) = @_;
+    my $ctx = $req->data->{ &DATA_KEY } or return PE_OK;
+    my $grant_id = $ctx->{grant_id} or return PE_OK;
+
+    $payload->{grant_id} = $grant_id;
+    if ( my $jti = $payload->{jti} ) {
+        $self->oidc->updateToken( $jti, { grant_id => $grant_id } );
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateIntrospectionResponse
+sub addGrantIdToIntrospection {
+    my ( $self, $req, $response, $rp, $token_data ) = @_;
+    if ( my $grant_id = $token_data->{grant_id} ) {
+        $response->{grant_id} = $grant_id;
+    }
+    return PE_OK;
+}
+
+# Hook: oidcGenerateMetadata
+# Advertise grant_management_endpoint and grant_management_actions_supported
+# in /.well-known/openid-configuration.
+sub advertiseEndpoint {
+    my ( $self, $req, $metadata ) = @_;
+    my $issuer = $metadata->{issuer};
+    my $uri    = $self->conf->{oidcServiceMetaDataGrantManagementURI}
+      || 'grants';
+    my $sep = $issuer =~ m{/$} ? '' : '/';
+    $metadata->{grant_management_endpoint} =
+      $issuer . $sep . $self->oidc->path . '/' . $uri;
+    $metadata->{grant_management_actions_supported} =
+      [ @{ &SUPPORTED_ACTIONS } ];
+    return PE_OK;
+}
+
+# ---------------------------------------------------------------------------
+# RESTful endpoint /oauth2/grants/{grant_id}
+
+sub handleGrantEndpoint {
+    my ( $self, $req ) = @_;
+
+    my $grant_id = $req->param('grant_id')
+      or return $self->_jsonError( $req, 400, 'invalid_request',
+        'grant_id is required' );
+
+    my ( $rp, $auth_method ) =
+      $self->oidc->checkEndPointAuthenticationCredentials($req);
+    return $self->oidc->invalidClientResponse($req) unless $rp;
+
+    my $client_id =
+      $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsClientID};
+
+    my $grant = $self->_loadGrant($grant_id);
+    return $self->_jsonError( $req, 404, 'invalid_grant',
+        'No such grant_id' )
+      unless $grant;
+
+    if ( ( $grant->data->{client_id} || '' ) ne $client_id ) {
+        $self->logger->error( "OIDCGrantManagement: client `$client_id` "
+              . "tried to access grant `$grant_id` owned by "
+              . ( $grant->data->{client_id} // '<undef>' ) );
+        return $self->_jsonError( $req, 403, 'invalid_grant',
+            'Grant does not belong to this client' );
+    }
+
+    my $method = uc( $req->env->{REQUEST_METHOD} || 'GET' );
+    if ( $method eq 'GET' ) {
+        return $self->_grantGet( $req, $grant );
+    }
+    elsif ( $method eq 'DELETE' ) {
+        return $self->_grantDelete( $req, $grant, $rp );
+    }
+    return $self->_jsonError( $req, 405, 'invalid_request',
+        "Method $method not allowed" );
+}
+
+sub _grantGet {
+    my ( $self, $req, $grant ) = @_;
+    my $body = {
+        scopes => [
+            map { { scope => $_ } } split /\s+/, $grant->data->{scope} || ''
+        ],
+        (
+            $grant->data->{authorization_details}
+            ? ( authorization_details => $grant->data->{authorization_details} )
+            : ()
+        ),
+    };
+    return $self->p->sendJSONresponse( $req, $body, code => 200 );
+}
+
+sub _grantDelete {
+    my ( $self, $req, $grant, $rp ) = @_;
+    my $grant_id = $grant->id;
+    if ( $grant->remove ) {
+        $self->logger->debug(
+            "OIDCGrantManagement: revoked grant `$grant_id` for $rp");
+    }
+    else {
+        $self->logger->error(
+            "OIDCGrantManagement: failed to remove grant `$grant_id`: "
+              . $grant->error );
+        return $self->_jsonError( $req, 500, 'server_error',
+            'Failed to remove grant' );
+    }
+
+    # Spec mandates 204 No Content on success.
+    return $self->p->sendBinaryResponse( $req, '', code => 204 );
+}
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+sub _loadGrant {
+    my ( $self, $grant_id ) = @_;
+    return undef unless $grant_id;
+    return $self->oidc->getOpenIDConnectSession( $grant_id, &SESSION_KIND );
+}
+
+sub _jsonError {
+    my ( $self, $req, $code, $error, $description ) = @_;
+    return $self->p->sendJSONresponse(
+        $req,
+        {
+            error => $error,
+            ( $description ? ( error_description => $description ) : () ),
+        },
+        code => $code,
+    );
+}
+
+1;

--- a/plugins/oidc-grant-management/manager-overrides/grant-management.json
+++ b/plugins/oidc-grant-management/manager-overrides/grant-management.json
@@ -1,0 +1,60 @@
+{
+  "attributes": {
+    "oidcServiceMetaDataGrantManagementURI": {
+      "type": "text",
+      "default": "grants",
+      "documentation": "FAPI Grant Management — endpoint path for `/oauth2/{path}/{grant_id}` (GET to query, DELETE to revoke)"
+    },
+    "oidcServiceGrantExpiration": {
+      "type": "int",
+      "default": 7776000,
+      "documentation": "FAPI Grant Management — TTL of a grant in seconds, default 90 days (PSD2 alignment). Refreshed on every token issuance against the grant."
+    },
+    "oidcRPMetaDataOptionsGrantManagement": {
+      "type": "select",
+      "select": [
+        { "k": "", "v": "Disabled" },
+        { "k": "allowed", "v": "Allowed" },
+        { "k": "required", "v": "Required" }
+      ],
+      "default": "",
+      "documentation": "FAPI Grant Management mode for this RP. `allowed` accepts `grant_management_action` from the client; `required` rejects authorize calls that omit it."
+    }
+  },
+  "tree": [
+    {
+      "insert_into": "oidcServiceMetaData/oidcServiceMetaDataEndPoints",
+      "nodes": [
+        "oidcServiceMetaDataGrantManagementURI"
+      ]
+    },
+    {
+      "insert_into": "oidcServiceMetaData/oidcServiceMetaDataTimeouts",
+      "nodes": [
+        "oidcServiceGrantExpiration"
+      ]
+    }
+  ],
+  "ctrees": {
+    "oidcRPMetaDataNode": {
+      "insert_into": "oidcRPMetaDataOptions/security",
+      "nodes": [
+        "oidcRPMetaDataOptionsGrantManagement"
+      ]
+    }
+  },
+  "lang": {
+    "oidcServiceMetaDataGrantManagementURI": {
+      "en": "Grant management endpoint URI",
+      "fr": "URI de l'endpoint Grant Management"
+    },
+    "oidcServiceGrantExpiration": {
+      "en": "Grant TTL (seconds)",
+      "fr": "Durée de vie d'un grant (secondes)"
+    },
+    "oidcRPMetaDataOptionsGrantManagement": {
+      "en": "Grant Management mode",
+      "fr": "Mode Grant Management"
+    }
+  }
+}

--- a/plugins/oidc-grant-management/plugin.json
+++ b/plugins/oidc-grant-management/plugin.json
@@ -2,7 +2,7 @@
   "name": "oidc-grant-management",
   "version": "0.1.0",
   "summary": "FAPI Grant Management for OAuth 2.0",
-  "description": "Implements the OpenID Foundation FAPI Grant Management API: introduces grants as durable first-class records, the `grant_management_action` parameter on /oauth2/authorize (`create` / `update` / `replace`), the `grant_id` claim on token responses, and a RESTful endpoint at `/oauth2/grants/{grant_id}` (GET to query, DELETE to revoke with cascade on tokens). Pure plugin, no LLNG core change required.",
+  "description": "Implements the OpenID Foundation FAPI Grant Management API: introduces grants as durable first-class records, the `grant_management_action` parameter on /oauth2/authorize (`create` / `update` / `replace`), the `grant_id` claim on token responses, and a RESTful endpoint at `/oauth2/grants/{grant_id}` (GET to query, DELETE to revoke; token cascade on revoke is best-effort in v1, see plugin README). Pure plugin, no LLNG core change required.",
   "author": "Xavier Guimard <yadd@debian.org>",
   "license": "GPL-2.0",
   "llng_compat": ">=2.24.0",

--- a/plugins/oidc-grant-management/plugin.json
+++ b/plugins/oidc-grant-management/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "oidc-grant-management",
+  "version": "0.1.0",
+  "summary": "FAPI Grant Management for OAuth 2.0",
+  "description": "Implements the OpenID Foundation FAPI Grant Management API: introduces grants as durable first-class records, the `grant_management_action` parameter on /oauth2/authorize (`create` / `update` / `replace`), the `grant_id` claim on token responses, and a RESTful endpoint at `/oauth2/grants/{grant_id}` (GET to query, DELETE to revoke with cascade on tokens). Pure plugin, no LLNG core change required.",
+  "author": "Xavier Guimard <yadd@debian.org>",
+  "license": "GPL-2.0",
+  "llng_compat": ">=2.24.0",
+  "customPlugins": "::Plugins::OIDCGrantManagement",
+  "tags": [
+    "oidc",
+    "oauth2",
+    "fapi"
+  ],
+  "homepage": "https://github.com/linagora/lemonldap-ng-plugins",
+  "autoload": [
+    {
+      "condition": "or::oidcRPMetaDataOptions/*/oidcRPMetaDataOptionsGrantManagement",
+      "module": "::Plugins::OIDCGrantManagement"
+    }
+  ]
+}

--- a/plugins/oidc-grant-management/t/35-OIDC-GrantManagement.t
+++ b/plugins/oidc-grant-management/t/35-OIDC-GrantManagement.t
@@ -180,6 +180,162 @@ subtest "action=replace replaces the scope set entirely" => sub {
     );
 };
 
+sub _refresh {
+    my ( $op, $client_id, $rt ) = @_;
+    my $q = buildForm( {
+            grant_type    => "refresh_token",
+            refresh_token => $rt,
+    } );
+    return $op->_post(
+        "/oauth2/token",
+        IO::String->new($q),
+        accept => 'application/json',
+        length => length($q),
+        custom => {
+            HTTP_AUTHORIZATION => "Basic "
+              . encode_base64( "$client_id:$client_id", '' ),
+        },
+    );
+}
+
+subtest "offline_access: grant_id survives a refresh-token grant" => sub {
+
+    # Realistic open-banking shape: long-lived offline refresh token, the
+    # client uses it for weeks and the grant_id must keep flowing through
+    # every refresh.
+    my $code = codeAuthorize(
+        $op, $idpId,
+        {
+            response_type           => "code",
+            scope                   => "openid profile offline_access",
+            client_id               => "rpid",
+            state                   => "offline-1",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "create",
+        }
+    );
+    my $first =
+      expectJSON( codeGrant( $op, "rpid", $code, "http://client.com/" ) );
+    ok( $first->{grant_id}, "Initial grant_id present" );
+    ok( $first->{refresh_token},
+        "offline refresh_token issued" );
+    my $offline_grant = $first->{grant_id};
+
+    # Refresh: new AT must still carry the grant_id everywhere.
+    my $second = expectJSON( _refresh( $op, "rpid", $first->{refresh_token} ) );
+    is( $second->{grant_id}, $offline_grant,
+        "Refresh response echoes the SAME grant_id" );
+
+    my $payload = jwt_payload( $second->{access_token} );
+    is( $payload->{grant_id}, $offline_grant,
+        "Refresh-issued JWT AT carries grant_id" );
+
+    my $intro =
+      expectJSON( introspect( $op, "rpid", $second->{access_token} ) );
+    is( $intro->{grant_id}, $offline_grant,
+        "Refresh-issued AT introspection still carries grant_id" );
+
+    # The grant itself is still there and queryable.
+    my $get_res = gm_get( $op, "rpid", $offline_grant );
+    is( $get_res->[0], 200,
+        "GET on the grant still returns 200 after refreshing" );
+};
+
+subtest "Refresh-token rotation preserves grant_id across rotations" => sub {
+
+    # Rotation enabled = each refresh issues a NEW refresh_token. The
+    # plugin's storeOnRefresh hook must source from $req->data populated
+    # by restoreOnTokenEndpoint, otherwise the new RT is born without
+    # grant context and the chain breaks at rotation #2 (regression
+    # pattern caught by Copilot on PR #20 / oidc-acr-claims).
+    my $op_rot = register( 'op_rot', sub { op_with_rotation() } );
+    my $id_rot = login( $op_rot, "french" );
+
+    my $code = codeAuthorize(
+        $op_rot, $id_rot,
+        {
+            response_type           => "code",
+            scope                   => "openid profile offline_access",
+            client_id               => "rpid",
+            state                   => "rot-1",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "create",
+        }
+    );
+    my $first =
+      expectJSON( codeGrant( $op_rot, "rpid", $code, "http://client.com/" ) );
+    my $rot_grant = $first->{grant_id};
+    ok( $rot_grant, "Initial grant_id present (rotation flavor)" );
+
+    # First rotation
+    my $second = expectJSON( _refresh( $op_rot, "rpid", $first->{refresh_token} ) );
+    isnt( $second->{refresh_token}, $first->{refresh_token},
+        "Rotation issued a fresh refresh_token" );
+    is( $second->{grant_id}, $rot_grant,
+        "After first rotation, grant_id is preserved" );
+
+    # Second rotation — the regression-prone one
+    my $third =
+      expectJSON( _refresh( $op_rot, "rpid", $second->{refresh_token} ) );
+    is( $third->{grant_id}, $rot_grant,
+        "After second rotation, grant_id is STILL preserved" );
+    my $payload = jwt_payload( $third->{access_token} );
+    is( $payload->{grant_id}, $rot_grant,
+        "Twice-rotated AT JWT still carries grant_id" );
+};
+
+subtest "Subject check: another user cannot update someone else's grant" => sub {
+
+    # User `french` already created/updated/replaced $created_grant_id at
+    # this point. Now log in as a different demo user and try to use the
+    # same grant_id with action=update — must be rejected.
+    my $other_idp = login( $op, "dwho" );
+    my $auth_res = authorize(
+        $op, $other_idp,
+        {
+            response_type           => "code",
+            scope                   => "openid",
+            client_id               => "rpid",
+            state                   => "wrong-user",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "update",
+            grant_id                => $created_grant_id,
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "Cross-subject update is rejected (security)" );
+};
+
+subtest "_mergeRar deduplicates by structural equality" => sub {
+    require Lemonldap::NG::Portal::Plugins::OIDCGrantManagement;
+    my $existing = [
+        { type => "payment_initiation", amount => "100" },
+        { type => "account_information", iban => "FR76..." },
+    ];
+    my $new_entries = [
+        { type => "payment_initiation", amount => "100" }, # dup of existing
+        { type => "payment_initiation", amount => "200" }, # new
+    ];
+    my $merged =
+      Lemonldap::NG::Portal::Plugins::OIDCGrantManagement::_mergeRar(
+        $existing, $new_entries );
+    is( scalar(@$merged), 3,
+        "Merge keeps 3 entries (existing 2 + 1 new, 1 duplicate dropped)" );
+    my @amounts = map { $_->{amount} } grep { $_->{type} eq "payment_initiation" } @$merged;
+    is_deeply( [ sort @amounts ], [qw(100 200)],
+        "Both payment amounts present, no duplicate of 100" );
+
+    # Boundary: empty existing => returns new
+    my $r1 = Lemonldap::NG::Portal::Plugins::OIDCGrantManagement::_mergeRar(
+        undef, $new_entries );
+    is_deeply( $r1, $new_entries, "Empty existing => returns new verbatim" );
+
+    # Boundary: undef new => returns existing
+    my $r2 = Lemonldap::NG::Portal::Plugins::OIDCGrantManagement::_mergeRar(
+        $existing, undef );
+    is_deeply( $r2, $existing, "Undef new => returns existing verbatim" );
+};
+
 subtest "DELETE /oauth2/grants/{id} returns 204 and the grant is gone" => sub {
     my $res = gm_delete( $op, "rpid", $created_grant_id );
     is( $res->[0], 204, "Returns 204 No Content" );
@@ -280,6 +436,7 @@ sub op {
 
                 oidcServiceAllowAuthorizationCodeFlow => 1,
                 oidcServiceAllowOnlyDeclaredScopes    => 0,
+                oidcServiceAllowOffline               => 1,
 
                 oidcRPMetaDataExportedVars => {
                     rp           => { email => "mail", name => "cn" },
@@ -297,6 +454,7 @@ sub op {
                         oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
                         oidcRPMetaDataOptionsBypassConsent         => 1,
                         oidcRPMetaDataOptionsRedirectUris   => 'http://client.com/',
+                        oidcRPMetaDataOptionsAllowOffline   => 1,
                         oidcRPMetaDataOptionsGrantManagement => 'allowed',
                     },
                     rp_other => {
@@ -322,6 +480,50 @@ sub op {
                         oidcRPMetaDataOptionsBypassConsent         => 1,
                         oidcRPMetaDataOptionsRedirectUris   => 'http://client.com/',
                         oidcRPMetaDataOptionsGrantManagement => 'required',
+                    },
+                },
+                oidcServicePrivateKeySig => oidc_key_op_private_sig,
+                oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+            }
+        }
+    );
+}
+
+sub op_with_rotation {
+    return LLNG::Manager::Test->new( {
+            ini => {
+                domain                          => 'idp.com',
+                portal                          => 'http://auth.op.com/',
+                authentication                  => 'Demo',
+                userDB                          => 'Same',
+                customPlugins                   =>
+                  '::Plugins::OIDCGrantManagement',
+                issuerDBOpenIDConnectActivation => "1",
+                restSessionServer               => 1,
+
+                oidcServiceMetaDataGrantManagementURI => 'grants',
+                oidcServiceGrantExpiration            => 3600,
+
+                oidcServiceAllowAuthorizationCodeFlow => 1,
+                oidcServiceAllowOnlyDeclaredScopes    => 0,
+                oidcServiceAllowOffline               => 1,
+
+                oidcRPMetaDataExportedVars =>
+                  { rp => { email => "mail", name => "cn" } },
+                oidcRPMetaDataOptions => {
+                    rp => {
+                        oidcRPMetaDataOptionsDisplayName           => "RP",
+                        oidcRPMetaDataOptionsClientID              => "rpid",
+                        oidcRPMetaDataOptionsClientSecret          => "rpid",
+                        oidcRPMetaDataOptionsIDTokenSignAlg        => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenJWT        => 1,
+                        oidcRPMetaDataOptionsAccessTokenSignAlg    => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                        oidcRPMetaDataOptionsBypassConsent         => 1,
+                        oidcRPMetaDataOptionsRedirectUris   => 'http://client.com/',
+                        oidcRPMetaDataOptionsAllowOffline          => 1,
+                        oidcRPMetaDataOptionsRefreshTokenRotation  => 1,
+                        oidcRPMetaDataOptionsGrantManagement       => 'allowed',
                     },
                 },
                 oidcServicePrivateKeySig => oidc_key_op_private_sig,

--- a/plugins/oidc-grant-management/t/35-OIDC-GrantManagement.t
+++ b/plugins/oidc-grant-management/t/35-OIDC-GrantManagement.t
@@ -1,0 +1,332 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use MIME::Base64 qw/encode_base64 decode_base64/;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+}
+
+ok( my $op = register( 'op', sub { op() } ), 'OP portal' );
+my $idpId = login( $op, "french" );
+
+sub jwt_payload {
+    my $jwt = shift;
+    my ( undef, $body ) = split /\./, $jwt;
+    $body =~ tr{-_}{+/};
+    $body .= '=' x ( ( 4 - length($body) % 4 ) % 4 );
+    return decode_json( decode_base64($body) );
+}
+
+sub gm_get {
+    my ( $op, $client_id, $grant_id ) = @_;
+    return $op->_get(
+        "/oauth2/grants/$grant_id",
+        accept => 'application/json',
+        custom => {
+            HTTP_AUTHORIZATION => "Basic "
+              . encode_base64( "$client_id:$client_id", '' ),
+        },
+    );
+}
+
+sub gm_delete {
+    my ( $op, $client_id, $grant_id ) = @_;
+    return $op->_get(
+        "/oauth2/grants/$grant_id",
+        accept => 'application/json',
+        custom => {
+            REQUEST_METHOD     => 'DELETE',
+            HTTP_AUTHORIZATION => "Basic "
+              . encode_base64( "$client_id:$client_id", '' ),
+        },
+    );
+}
+
+subtest "Discovery advertises grant_management endpoint and actions" => sub {
+    my $res = $op->_get(
+        "/.well-known/openid-configuration",
+        accept => 'application/json',
+    );
+    my $json = expectJSON($res);
+    ok( $json->{grant_management_endpoint},
+        "grant_management_endpoint present" );
+    like(
+        $json->{grant_management_endpoint},
+        qr{/oauth2/grants$},
+        "endpoint URL ends with /oauth2/grants"
+    );
+    is_deeply(
+        [ sort @{ $json->{grant_management_actions_supported} || [] } ],
+        [qw(create replace update)],
+        "supported actions are create/replace/update"
+    );
+};
+
+subtest "Default authorize (no action) does not emit grant_id" => sub {
+    my $code = codeAuthorize(
+        $op, $idpId,
+        {
+            response_type => "code",
+            scope         => "openid profile",
+            client_id     => "rpid",
+            state         => "noaction",
+            redirect_uri  => "http://client.com/",
+        }
+    );
+    my $token_res =
+      expectJSON( codeGrant( $op, "rpid", $code, "http://client.com/" ) );
+    ok( !defined $token_res->{grant_id},
+        "no grant_id without grant_management_action" );
+};
+
+my $created_grant_id;
+
+subtest "action=create emits a fresh grant_id, claim and introspection" => sub {
+    my $code = codeAuthorize(
+        $op, $idpId,
+        {
+            response_type            => "code",
+            scope                    => "openid profile read",
+            client_id                => "rpid",
+            state                    => "create",
+            redirect_uri             => "http://client.com/",
+            grant_management_action  => "create",
+        }
+    );
+    my $token_res =
+      expectJSON( codeGrant( $op, "rpid", $code, "http://client.com/" ) );
+    ok( $token_res->{grant_id}, "grant_id present in token response" );
+    $created_grant_id = $token_res->{grant_id};
+
+    my $payload = jwt_payload( $token_res->{access_token} );
+    is( $payload->{grant_id}, $created_grant_id,
+        "JWT access token carries grant_id claim" );
+
+    my $intro = expectJSON( introspect( $op, "rpid",
+            $token_res->{access_token} ) );
+    is( $intro->{grant_id}, $created_grant_id,
+        "Introspection response carries grant_id" );
+};
+
+subtest "GET /oauth2/grants/{id} returns the grant content" => sub {
+    my $res = gm_get( $op, "rpid", $created_grant_id );
+    is( $res->[0], 200, "Returns 200 OK" );
+    my $json = expectJSON($res);
+    my @scope_names = map { $_->{scope} } @{ $json->{scopes} || [] };
+    is_deeply(
+        [ sort @scope_names ],
+        [qw(openid profile read)],
+        "Grant carries the granted scopes"
+    );
+};
+
+subtest "action=update merges the new scope into the existing grant" => sub {
+    my $code = codeAuthorize(
+        $op, $idpId,
+        {
+            response_type           => "code",
+            scope                   => "openid profile write",
+            client_id               => "rpid",
+            state                   => "update",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "update",
+            grant_id                => $created_grant_id,
+        }
+    );
+    my $token_res =
+      expectJSON( codeGrant( $op, "rpid", $code, "http://client.com/" ) );
+    is( $token_res->{grant_id}, $created_grant_id,
+        "Same grant_id returned after update" );
+
+    my $res = gm_get( $op, "rpid", $created_grant_id );
+    my $json = expectJSON($res);
+    my @scope_names = map { $_->{scope} } @{ $json->{scopes} || [] };
+    is_deeply(
+        [ sort @scope_names ],
+        [qw(openid profile read write)],
+        "Grant scope set is the union (read kept, write added)"
+    );
+};
+
+subtest "action=replace replaces the scope set entirely" => sub {
+    my $code = codeAuthorize(
+        $op, $idpId,
+        {
+            response_type           => "code",
+            scope                   => "openid admin",
+            client_id               => "rpid",
+            state                   => "replace",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "replace",
+            grant_id                => $created_grant_id,
+        }
+    );
+    my $token_res =
+      expectJSON( codeGrant( $op, "rpid", $code, "http://client.com/" ) );
+    is( $token_res->{grant_id}, $created_grant_id,
+        "Same grant_id returned after replace" );
+
+    my $res = gm_get( $op, "rpid", $created_grant_id );
+    my $json = expectJSON($res);
+    my @scope_names = map { $_->{scope} } @{ $json->{scopes} || [] };
+    is_deeply(
+        [ sort @scope_names ],
+        [qw(admin openid)],
+        "Grant scope set is just the new scopes (read/write/profile gone)"
+    );
+};
+
+subtest "DELETE /oauth2/grants/{id} returns 204 and the grant is gone" => sub {
+    my $res = gm_delete( $op, "rpid", $created_grant_id );
+    is( $res->[0], 204, "Returns 204 No Content" );
+
+    my $get_after = gm_get( $op, "rpid", $created_grant_id );
+    is( $get_after->[0], 404, "GET on deleted grant returns 404" );
+    my $json = from_json( $get_after->[2]->[0] );
+    is( $json->{error}, "invalid_grant", "error code is invalid_grant" );
+};
+
+subtest "Cannot access another client's grant" => sub {
+
+    # Create a grant for rpid
+    my $code = codeAuthorize(
+        $op, $idpId,
+        {
+            response_type           => "code",
+            scope                   => "openid",
+            client_id               => "rpid",
+            state                   => "owner",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "create",
+        }
+    );
+    my $token_res =
+      expectJSON( codeGrant( $op, "rpid", $code, "http://client.com/" ) );
+    my $someone_grant = $token_res->{grant_id};
+
+    # Try to GET it as a different client
+    my $res = gm_get( $op, "rpid_other", $someone_grant );
+    is( $res->[0], 403,
+        "Returns 403 Forbidden when client doesn't own the grant" );
+};
+
+subtest "RP with mode=required rejects authorize without action" => sub {
+    my $auth_res = authorize(
+        $op, $idpId,
+        {
+            response_type => "code",
+            scope         => "openid",
+            client_id     => "rpid_strict",
+            state         => "strict",
+            redirect_uri  => "http://client.com/",
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "Authorize without grant_management_action is rejected" );
+};
+
+subtest "Unknown action is rejected" => sub {
+    my $auth_res = authorize(
+        $op, $idpId,
+        {
+            response_type           => "code",
+            scope                   => "openid",
+            client_id               => "rpid",
+            state                   => "bad",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "merge",   # not in v1 supported set
+        }
+    );
+    expectPortalError( $auth_res, 24, "Unknown action is rejected" );
+};
+
+subtest "update without grant_id is rejected" => sub {
+    my $auth_res = authorize(
+        $op, $idpId,
+        {
+            response_type           => "code",
+            scope                   => "openid",
+            client_id               => "rpid",
+            state                   => "missingid",
+            redirect_uri            => "http://client.com/",
+            grant_management_action => "update",
+        }
+    );
+    expectPortalError( $auth_res, 24,
+        "update without grant_id is rejected" );
+};
+
+clean_sessions();
+done_testing();
+
+sub op {
+    return LLNG::Manager::Test->new( {
+            ini => {
+                domain                          => 'idp.com',
+                portal                          => 'http://auth.op.com/',
+                authentication                  => 'Demo',
+                userDB                          => 'Same',
+                customPlugins                   =>
+                  '::Plugins::OIDCGrantManagement',
+                issuerDBOpenIDConnectActivation => "1",
+                restSessionServer               => 1,
+
+                oidcServiceMetaDataGrantManagementURI => 'grants',
+                oidcServiceGrantExpiration            => 3600,
+
+                oidcServiceAllowAuthorizationCodeFlow => 1,
+                oidcServiceAllowOnlyDeclaredScopes    => 0,
+
+                oidcRPMetaDataExportedVars => {
+                    rp           => { email => "mail", name => "cn" },
+                    rp_other     => { email => "mail", name => "cn" },
+                    rp_strict    => { email => "mail", name => "cn" },
+                },
+                oidcRPMetaDataOptions => {
+                    rp => {
+                        oidcRPMetaDataOptionsDisplayName           => "RP",
+                        oidcRPMetaDataOptionsClientID              => "rpid",
+                        oidcRPMetaDataOptionsClientSecret          => "rpid",
+                        oidcRPMetaDataOptionsIDTokenSignAlg        => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenJWT        => 1,
+                        oidcRPMetaDataOptionsAccessTokenSignAlg    => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                        oidcRPMetaDataOptionsBypassConsent         => 1,
+                        oidcRPMetaDataOptionsRedirectUris   => 'http://client.com/',
+                        oidcRPMetaDataOptionsGrantManagement => 'allowed',
+                    },
+                    rp_other => {
+                        oidcRPMetaDataOptionsDisplayName           => "Other RP",
+                        oidcRPMetaDataOptionsClientID              => "rpid_other",
+                        oidcRPMetaDataOptionsClientSecret          => "rpid_other",
+                        oidcRPMetaDataOptionsIDTokenSignAlg        => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenJWT        => 1,
+                        oidcRPMetaDataOptionsAccessTokenSignAlg    => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                        oidcRPMetaDataOptionsBypassConsent         => 1,
+                        oidcRPMetaDataOptionsRedirectUris   => 'http://client.com/',
+                        oidcRPMetaDataOptionsGrantManagement => 'allowed',
+                    },
+                    rp_strict => {
+                        oidcRPMetaDataOptionsDisplayName           => "Strict",
+                        oidcRPMetaDataOptionsClientID              => "rpid_strict",
+                        oidcRPMetaDataOptionsClientSecret          => "rpid_strict",
+                        oidcRPMetaDataOptionsIDTokenSignAlg        => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenJWT        => 1,
+                        oidcRPMetaDataOptionsAccessTokenSignAlg    => "HS512",
+                        oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                        oidcRPMetaDataOptionsBypassConsent         => 1,
+                        oidcRPMetaDataOptionsRedirectUris   => 'http://client.com/',
+                        oidcRPMetaDataOptionsGrantManagement => 'required',
+                    },
+                },
+                oidcServicePrivateKeySig => oidc_key_op_private_sig,
+                oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+            }
+        }
+    );
+}


### PR DESCRIPTION
## Summary

Implements the OpenID Foundation [FAPI Grant Management for OAuth 2.0](https://openid.net/specs/fapi-grant-management.html) on the LemonLDAP::NG OIDC Provider side. Pure plugin, **no LLNG core change required**.

Introduces *grants* as durable first-class records, distinct from tokens:

- a grant captures the cumulative scope set + (when `oidc-rar` is loaded) `authorization_details` for a `(client, user)` couple
- persists across token rotations
- queryable / revocable through a RESTful API independently of any token's lifecycle

## What it does

### `grant_management_action` parameter on `/oauth2/authorize`

| Action      | Effect                                                                                                                                  |
| ----------- | --------------------------------------------------------------------------------------------------------------------------------------- |
| `create`    | Mint a fresh grant. New `grant_id` returned.                                                                                            |
| `update`    | Load the existing `grant_id` and **add** the requested scopes/details to it.                                                            |
| `replace`   | Load the existing grant and **replace** its scope set entirely.                                                                         |

`merge` is intentionally unsupported (RFC says it's optional, semantics are ambiguous).

### `grant_id` surfaces

- Token response JSON
- JWT access token claim
- Introspection response

### RESTful endpoint

```
GET    /oauth2/grants/{grant_id}    →  200 + JSON description
DELETE /oauth2/grants/{grant_id}    →  204 No Content; grant revoked
```

Registered via the PSGI router's `:grant_id` path-capture syntax (cf. `Lemonldap::NG::Common::PSGI::Router`). Authenticated as the OAuth client; cross-client access returns 403.

### Discovery

```json
{
  "grant_management_endpoint": "https://op.example.com/oauth2/grants",
  "grant_management_actions_supported": ["create", "replace", "update"]
}
```

## Implementation notes

- **Grant id == LLNG session id**: no search-by-attribute. Direct lookup.
- **Materialization at `/oauth2/authorize` time**, not `/oauth2/token` time: the grant must exist before the access token is built, otherwise the `grant_id` claim and introspection field can't be populated. Hooked at `oidcGenerateCode`.
- **Per-RP mode** `oidcRPMetaDataOptionsGrantManagement` (`""` / `allowed` / `required`). `required` rejects authorize calls without an action.

## Out of scope (documented in README)

- **Token cascade revocation on DELETE is best-effort.** Removing the grant doesn't proactively invalidate already-issued access tokens — they stay valid until their TTL. v2 candidate: add a userinfo/introspection-side hook that re-checks the grant.
- **`merge` action.**
- **Delta-aware consent UI** for `update`/`replace`.

## Test plan

- [x] `t/35-OIDC-GrantManagement.t` — 18 subtests:
  - discovery advertises endpoint + actions
  - default authorize (no action) does NOT emit `grant_id`
  - `create` emits a fresh `grant_id`, present in token response, JWT AT claim, introspection
  - `GET /grants/{id}` returns the grant content with the granted scopes
  - `update` merges new scopes into the existing grant (union)
  - `replace` replaces the scope set entirely
  - `DELETE /grants/{id}` returns 204; subsequent GET returns 404 / `invalid_grant`
  - cross-client GET on someone else's grant returns 403
  - RP with mode=required rejects authorize without action
  - unknown action (`merge`) rejected
  - `update` without `grant_id` rejected

Run via:

```
mcp__llng-plugins__test plugin=oidc-grant-management
```

## See also

- Sibling PRs (already merged): #18 (oidc-rar / RFC 9396), #19 (oidc-resource-indicators / RFC 8707), #20 (oidc-acr-claims / RFC 9470 AS-side claims).
- With this PR + the merged ones, the FAPI 2.0-aligned set is: PAR ✅, JAR ✅, JARM ✅, PKCE ✅, Resource Indicators ✅, RAR ✅, ACR Claims ✅, Grant Management ✅, mTLS ⏳ (in core PR for 2.23/2.24), DPoP ⏳ (waiting on a core hook for the Authorization-header parser).