### PR TITLE
fix(llng-build-manager-files): register plugin hash containers in $hashParameters

### DIFF
--- a/store/scripts/llng-build-manager-files
+++ b/store/scripts/llng-build-manager-files
@@ -417,6 +417,60 @@ s{^(use constant DEFAULTCONFFILE\s*=>\s*").*("\s*;)}{$1$saved_conffile$2}m
     }
 }
 
+# 6c. Extend $hashParameters in Constants.pm with plugin-introduced
+#     hash-of-X containers that are ctree leaves.
+#
+#     Background: Build.pm scans tree() and pushes top-level attributes of
+#     type *Container / catAndAppList into @simpleHashKeys, which feeds
+#     $hashParameters in Constants.pm. But when the same attribute is a
+#     ctree leaf (i.e. scanned with a $prefix), it is intentionally NOT
+#     pushed (Build.pm:787 `unless ( $prefix or ... )`). Core works around
+#     this by listing its own ctree-leaf containers in a hardcoded list
+#     (oidcRPMetaDataExportedVars, oidcRPMetaDataMacros, ...). Plugins
+#     cannot extend that list at build time; without help, their
+#     containers stay out of $hashParameters and Serializer/Backends
+#     silently mis-handle the data (stored / read as raw string instead
+#     of a hashref).
+#
+#     This step mirrors core's hardcoded list, but for extensions: any
+#     extension-introduced attribute of container type gets appended to
+#     $hashParameters via a non-capturing alternation.
+if ( $conf_constants_file ne '/dev/null' && -r $conf_constants_file ) {
+    my @ext_hash_attrs =
+      sort
+      grep {
+        my $t = $ext_attributes->{$_}{type} // '';
+        $t =~ /^(?:catAndAppList|\w+Container)$/;
+      } keys %$ext_attributes;
+
+    if (@ext_hash_attrs) {
+        verbose "Extending \$hashParameters with "
+          . scalar(@ext_hash_attrs)
+          . " extension hash container(s): @ext_hash_attrs\n";
+
+        open my $fh, '<', $conf_constants_file
+          or die "Cannot read $conf_constants_file: $!";
+        my $content = do { local $/; <$fh> };
+        close $fh;
+
+        my $alt = join '|', map quotemeta, @ext_hash_attrs;
+        my $matched = ( $content =~
+              s{^(our\s+\$hashParameters\s*=\s*qr/\^)(.+?)(\$/;)}
+               {$1(?:$2|$alt)$3}m );
+
+        if ($matched) {
+            open my $out, '>', $conf_constants_file
+              or die "Cannot write $conf_constants_file: $!";
+            print $out $content;
+            close $out;
+        }
+        else {
+            warn
+"Warning: could not extend \$hashParameters in $conf_constants_file (regex not found)\n";
+        }
+    }
+}
+
 # 6b. Minify conftree.js
 if ( $conftree_file ne '/dev/null' ) {
     minify_conftree($conftree_file);


### PR DESCRIPTION
## Summary

- Plugin-introduced container attributes (`keyTextContainer`, `catAndAppList`, ...) declared as ctree leaves are now added to `$hashParameters` after Build.pm runs.
- Without this, Serializer/Backends silently mis-handle their values (stored / read as raw JSON strings instead of hashrefs), so `$conf->{theKey}->{$rp}->{$inner}` returns `undef` at runtime.
- Mirrors what Build.pm:290-303 does for core's own ctree-leaf containers (`oidcRPMetaDataExportedVars`, `oidcRPMetaDataMacros`, `oidcRPMetaDataScopeRules`, ...).

## Root cause

`Build.pm` at line 787 skips `@simpleHashKeys` when scanning ctree leaves:

```perl
if ( $attr->{type} =~ /^(?:catAndAppList|\w+Container)$/ ) {
    $jleaf->{cnodes} = $prefix . $leaf;
    unless ( $prefix or $leaf =~ $reIgnoreKeys ) {
        push @simpleHashKeys, $leaf;          # <-- not reached for ctree leaves
    }
}
```

Core compensates by listing its own ctree-leaf containers in the hardcoded extra-list at `Build.pm:290-303`. Plugins have no way to extend that list from extension files.

## Fix

After `Build->run()` regenerates `Constants.pm`, the post-processing step iterates `$ext_attributes` for container types and extends the `$hashParameters` regex via a non-capturing alternation. No change to LLNG core required, no change required in plugin extension files.

## Effect on plugins in this repo

The following 3 keyTextContainer attributes were declared but unusable at runtime; they now round-trip through save/load correctly:

- `oidcRPMetaDataAuthorizationDetailsRules` — oidc-rar
- `oidcRPMetaDataRIScopes` — oidc-resource-indicators
- `oidcRPMetaDataRIScopeRules` — oidc-resource-indicators

## Test plan

- [x] Patched script copied into running `yadd/lemonldap-ng-manager` container; ran `lemonldap-ng-store rebuild`; verified the 3 new keys match `\$hashParameters` and core keys (`oidcRPMetaDataScopeRules`, `oidcRPMetaDataMacros`, `oidcRPMetaDataExportedVars`, `locationRules`) still match.
- [ ] After merge: rebuild Debian package and bump docker base image.