### PR TITLE
feat(llng-build-manager-files): reject plugin hash-of-X containers as ctree leaves

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,3 +140,63 @@ jobs:
 
       - name: Run tests
         run: ./mcp/cli.js execute "${{ matrix.plugin }}"
+
+  # Global lint: aggregate every plugin's manager-overrides/*.json under a
+  # single directory and run llng-build-manager-files against the union.
+  # Catches cross-plugin issues that per-plugin jobs miss because they only
+  # see their own override file. In particular it triggers the validation
+  # pass that rejects hash-of-X containers declared as ctree leaves.
+  validate-overrides:
+    needs: discover
+    if: needs.discover.outputs.has_tests == 'true'
+    runs-on: ubuntu-latest
+    name: validate manager-overrides
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install MCP/CLI dependencies
+        run: cd mcp && npm install --no-audit --no-fund
+
+      - name: Clone LLNG (default branch, shallow)
+        run: |
+          # Use any plugin to share the prepare logic (clone + make common).
+          ANY_PLUGIN=$(ls plugins | head -n1)
+          ./mcp/cli.js prepare "$ANY_PLUGIN"
+
+      - name: Install build-script Perl dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            libregexp-assemble-perl libjson-perl libio-string-perl perl
+
+      - name: Aggregate all plugin manager-overrides
+        run: |
+          mkdir -p .llng-overrides-all
+          for f in plugins/*/manager-overrides/*.json; do
+            [ -f "$f" ] || continue
+            cp "$f" .llng-overrides-all/
+          done
+          echo "Collected $(ls -1 .llng-overrides-all/*.json 2>/dev/null | wc -l) override file(s)"
+          ls -1 .llng-overrides-all/
+
+      - name: Run llng-build-manager-files in lint mode
+        run: |
+          export PERL5LIB="$PWD/.llng-test/lemonldap-ng/lemonldap-ng-manager/lib:$PWD/.llng-test/lemonldap-ng/lemonldap-ng-common/lib:$PWD/.llng-test/lemonldap-ng/lemonldap-ng-handler/lib:$PWD/.llng-test/lemonldap-ng/lemonldap-ng-portal/lib"
+          ./store/scripts/llng-build-manager-files \
+            --plugins-dir=.llng-overrides-all \
+            --struct-file=/dev/null \
+            --conftree-file=/dev/null \
+            --reverse-tree-file=/dev/null \
+            --manager-constants-file=/dev/null \
+            --manager-attributes-file=/dev/null \
+            --default-values-file=/dev/null \
+            --conf-constants-file=/dev/null \
+            --portal-constants-file=/dev/null \
+            --handler-status-constants-file=/dev/null \
+            --doc-constants-file=/dev/null \
+            --first-lmconf-file=/dev/null \
+            --lang-dir=/nonexistent

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -171,7 +171,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            libregexp-assemble-perl libjson-perl libio-string-perl perl
+            libregexp-assemble-perl libregexp-common-perl \
+            libjson-perl libio-string-perl libmouse-perl perl
 
       - name: Aggregate all plugin manager-overrides
         run: |

--- a/store/scripts/llng-build-manager-files
+++ b/store/scripts/llng-build-manager-files
@@ -163,12 +163,40 @@ else {
 }
 
 my @auth_plugins;
+my @ext_loaded;    # parallel to @ext_files, for post-load validation
 for my $ext_file (@ext_files) {
     verbose "Loading extension: $ext_file\n";
     my $ext = load_extension($ext_file);
     merge_extension( $attributes, $tree, $ctrees, $constants, $ext, $ext_file );
     push @auth_plugins, collect_auth_plugins( $ext->{authPlugin}, $ext_file );
+    push @ext_loaded, { file => $ext_file, ext => $ext };
 }
+
+# Reject extensions declaring hash-of-X containers as ctree leaves.
+#
+# Background: Build.pm pushes top-level *Container / catAndAppList
+# attributes into @simpleHashKeys (hence $hashParameters) only when
+# scanned without a $prefix (Build.pm:787). For its own ctree-leaf
+# containers (oidcRPMetaDataExportedVars, oidcRPMetaDataMacros, ...)
+# core compensates with a hardcoded list around Build.pm:291. That
+# list is the wiring point for ctree top-level hash keys and is
+# reserved for core.
+#
+# A plugin that declares a container attribute and references it as a
+# ctree leaf produces an attribute that is in $oidcRPMetaDataNodeKeys
+# (so Parser may accept it) but absent from $hashParameters. The
+# Serializer then stores / reads its value as a raw string, and
+# $conf->{theKey}->{$rp}->{$inner} returns undef at runtime: silent
+# data loss.
+#
+# Allowed patterns for a plugin:
+#   * scalar attributes (text, bool, int, select, longtext, url, ...)
+#     under oidcRPMetaDataOptions/* (or any existing Options namespace)
+#   * hash-of-X data encoded as JSON inside a scalar (longtext) leaf,
+#     with the plugin deserializing at runtime
+#   * a top-level config key via `tree:` (not `ctrees:`), which IS
+#     picked up by Build.pm's dynamic scan
+reject_plugin_ctree_containers( \@ext_loaded );
 
 # Warn on conflicting authPlugin declarations (same k with a different v
 # or a different role set across extension files). Dedup below keeps only
@@ -442,6 +470,100 @@ exit 0;
 #
 # Helper functions
 #
+
+# Walk ctree node specs and collect every string leaf reachable from them.
+# Each spec's nodes array may contain bare strings (leaf attribute names),
+# nested hashes with their own `nodes` array, or `nodes_cond` variants.
+sub _collect_ctree_leaves {
+    my ($nodes, $out) = @_;
+    return unless ref($nodes) eq 'ARRAY';
+    for my $n (@$nodes) {
+        if ( !ref($n) ) {
+            push @$out, $n if defined $n && length $n;
+        }
+        elsif ( ref($n) eq 'HASH' ) {
+            for my $k (qw(nodes nodes_cond)) {
+                _collect_ctree_leaves( $n->{$k}, $out ) if $n->{$k};
+            }
+        }
+    }
+}
+
+# Forbid hash-of-X containers declared by an extension and used as
+# ctree leaves. See the call site for the rationale and accepted
+# alternatives.
+sub reject_plugin_ctree_containers {
+    my ($ext_loaded) = @_;
+
+    my @violations;
+    for my $entry (@$ext_loaded) {
+        my $file = $entry->{file};
+        my $ext  = $entry->{ext};
+
+        my $attrs  = $ext->{attributes} || {};
+        my $ctrees = $ext->{ctrees}     || {};
+        next unless %$attrs && %$ctrees;
+
+        # Names of attributes declared by this extension that are
+        # container types (would need a $hashParameters entry).
+        my %declared_containers;
+        for my $name ( keys %$attrs ) {
+            my $type = ref( $attrs->{$name} ) eq 'HASH'
+              ? ( $attrs->{$name}{type} // '' )
+              : '';
+            $declared_containers{$name} = $type
+              if $type =~ /^(?:catAndAppList|\w+Container)$/;
+        }
+        next unless %declared_containers;
+
+        # Collect every leaf string reachable from this extension's
+        # ctree specs (across all ctree names, array-or-hash forms).
+        my @leaves;
+        for my $ctree_name ( keys %$ctrees ) {
+            my $spec  = $ctrees->{$ctree_name};
+            my @specs = ref $spec eq 'ARRAY' ? @$spec : ($spec);
+            for my $s (@specs) {
+                next unless ref($s) eq 'HASH';
+                _collect_ctree_leaves( $s->{nodes}, \@leaves );
+            }
+        }
+
+        my %seen_leaf = map { $_ => 1 } @leaves;
+        for my $name ( sort keys %declared_containers ) {
+            next unless $seen_leaf{$name};
+            push @violations,
+              {
+                file => $file,
+                name => $name,
+                type => $declared_containers{$name},
+              };
+        }
+    }
+
+    return unless @violations;
+
+    my $msg =
+        "Error: extensions declare hash-of-X containers as ctree leaves.\n"
+      . "Such attributes never end up in \$hashParameters and would be\n"
+      . "silently mis-serialized (stored / read as raw string instead of\n"
+      . "a hashref), causing \$conf->{theKey}->{\$rp}->{\$inner} to return\n"
+      . "undef at runtime.\n\n"
+      . "Offending declarations:\n";
+    for my $v (@violations) {
+        $msg .= "  - $v->{file}: $v->{name} (type=$v->{type})\n";
+    }
+    $msg .=
+        "\nAllowed alternatives:\n"
+      . "  * declare scalar attributes (text, bool, int, select, longtext,\n"
+      . "    url, ...) under an existing Options namespace\n"
+      . "    (e.g. oidcRPMetaDataOptions/*).\n"
+      . "  * to expose hash-of-X data per RP, encode it as JSON inside a\n"
+      . "    `longtext` leaf and have the plugin deserialize at runtime.\n"
+      . "  * for genuine top-level config keys, use `tree:` (not `ctrees:`);\n"
+      . "    Build.pm's dynamic scan picks them up automatically.\n";
+
+    die $msg;
+}
 
 sub load_extension {
     my ($file) = @_;


### PR DESCRIPTION
## Summary

- Adds a validation pass that fails the build when a plugin extension declares a `*Container` / `catAndAppList` attribute AND references it as a leaf inside its `ctrees:` block.
- Such attributes never end up in `\$hashParameters` (that namespace is reserved for core's ctree wiring at `Build.pm:291`). The Serializer would then store / read them as raw strings, causing `\$conf->{theKey}->{\$rp}->{\$inner}` to return `undef` at runtime — silent data loss.
- Error message names the offending file + attribute + type, and points to the three allowed alternatives.

## Allowed alternatives (described in the error)

1. Declare scalar attributes (text, bool, int, select, longtext, url, ...) under an existing Options namespace (e.g. `oidcRPMetaDataOptions/*`).
2. Encode hash-of-X data as JSON inside a `longtext` leaf, with the plugin deserializing at runtime.
3. For genuine top-level config keys, use `tree:` (not `ctrees:`) — Build.pm's dynamic scan picks them up automatically.

## Dependencies

This PR will currently fail the build for three already-shipped offenders. **Do not merge before** their refactor PRs land:

- [ ] `oidcRPMetaDataAuthorizationDetailsRules` — refactor in oidc-rar (separate PR)
- [ ] `oidcRPMetaDataRIScopes` — refactor in oidc-resource-indicators (separate PR)
- [ ] `oidcRPMetaDataRIScopeRules` — refactor in oidc-resource-indicators (same PR)

## Test plan

- [x] In a running yadd/lemonldap-ng-manager container, copy the patched script and run \`lemonldap-ng-store rebuild\`. With rar.json + ri.json present, build dies with the listed offenders. After removing them, build succeeds.
- [ ] After plugin refactors merge: full docker rebuild succeeds and the manager regex registries (\`\$hashParameters\`, \`\$oidcRPMetaDataNodeKeys\`) are consistent with the new scalar fields.