### PR TITLE
refactor(oidc-rar): encode per-type rules as JSON in a scalar option

### DIFF
--- a/OIDC.md
+++ b/OIDC.md
@@ -253,10 +253,9 @@ oidcRPMetaDataOptionsAcrClaims           = 1                    # acr + auth_tim
 oidcRPMetaDataOptionsAllowOffline        = 1
 
 # Per-RP rules: only allow payments above 1000 € when the user has done strong auth
-oidcRPMetaDataAuthorizationDetailsRules:
-  payment_initiation: |
-    $detail->{instructedAmount}->{amount} <= 1000
-    or $authenticationLevel >= 4
+# (JSON object: type → Perl expression)
+oidcRPMetaDataOptionsAuthorizationDetailsRules =
+  '{"payment_initiation": "$detail->{instructedAmount}->{amount} <= 1000 or $authenticationLevel >= 4"}'
 ```
 
 ### 5.2 Multi-API SaaS (Resource Indicators)

--- a/plugins/oidc-rar/README.md
+++ b/plugins/oidc-rar/README.md
@@ -63,12 +63,7 @@ In **Manager → _OIDC Relying Parties_ → `<rp>` → _Options_ → _Security_*
 | -------------------------------------------------- | ------- | --------------------------------------------------------------------------------- |
 | `oidcRPMetaDataOptionsAuthorizationDetailsEnabled` | `0`     | Accept `authorization_details` from this RP. Required to trigger plugin autoload. |
 | `oidcRPMetaDataOptionsAuthorizationDetailsTypes`   | _empty_ | Per-RP allowlist of `type` values, comma-separated. Empty = inherit global only.  |
-
-In **Manager → _OIDC Relying Parties_ → `<rp>` → _Options_ → _Scopes_ → _Authorization details rules_** :
-
-| Parameter                                 | Default | Description                                                                                                                                                |
-| ----------------------------------------- | ------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `oidcRPMetaDataAuthorizationDetailsRules` | `{}`    | Hash `type → Perl expression`. Mirrors the `oidcRPMetaDataScopeRules` mechanism: each rule is evaluated when an entry of the matching `type` is requested. |
+| `oidcRPMetaDataOptionsAuthorizationDetailsRules`   | _empty_ | JSON object `{"<type>": "<Perl expression>"}` of per-type rules; each rule is evaluated when an entry of the matching `type` is requested. Empty string = no rules. Invalid JSON denies all RAR requests for this RP (fail-closed). |
 
 ### Authorization model — three layers
 
@@ -79,12 +74,14 @@ Every requested `authorization_details` entry must clear all three:
    `oidcRPMetaDataOptionsAuthorizationDetailsTypes`. Either set being empty
    means "no restriction at that level". Both empty means any type goes.
 2. **Per-RP, per-type Perl rule** — if a rule is configured for the
-   requested entry's `type` in `oidcRPMetaDataAuthorizationDetailsRules`,
-   it is evaluated in LLNG's sandbox (`Safe::reval`), with the user session
-   attributes plus the magic variable `$detail` (full hashref of the
-   entry). Truthy result grants the entry; falsy rejects it (whole authorize
-   call fails). Types with no entry in this hash skip layer 2 (granted
-   subject to layer 1).
+   requested entry's `type` in
+   `oidcRPMetaDataOptionsAuthorizationDetailsRules` (a JSON object
+   `{type → perl_expr}`), it is evaluated in LLNG's sandbox
+   (`Safe::reval`), with the user session attributes plus the magic
+   variable `$detail` (full hashref of the entry). Truthy result grants
+   the entry; falsy rejects it (whole authorize call fails). Types with
+   no entry skip layer 2 (granted subject to layer 1). Invalid JSON or
+   uncompilable rule = deny-all (fail-closed).
 3. **User consent** _(optional, depending on the use case)_ — when
    `BypassConsent=0` for the RP, the operator's consent template
    (`oidcGiveConsent.tpl` / `oidcConsents.tpl`) can display `RAR_DETAILS`
@@ -120,12 +117,14 @@ plugin supports both — it never forces a consent screen.
 
 #### Example rules
 
-In `oidcRPMetaDataAuthorizationDetailsRules` for an RP, key = `type`, value
-= Perl expression:
+In `oidcRPMetaDataOptionsAuthorizationDetailsRules` for an RP, JSON object
+with key = `type` and value = Perl expression:
 
-```
-payment_initiation  =>  $groups =~ /\bbanking\b/ and $detail->{instructedAmount}->{amount} <= 1000
-account_information =>  $authenticationLevel >= 2
+```json
+{
+  "payment_initiation":  "$groups =~ /\\bbanking\\b/ and $detail->{instructedAmount}->{amount} <= 1000",
+  "account_information": "$authenticationLevel >= 2"
+}
 ```
 
 ## Where the granted details surface

--- a/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
+++ b/plugins/oidc-rar/lib/Lemonldap/NG/Portal/Plugins/OIDCRichAuthRequest.pm
@@ -55,6 +55,14 @@ has rpRarRule => (
     builder => '_buildRpRarRule',
 );
 
+# Set of RPs whose AuthorizationDetailsRules JSON failed to decode.
+# Populated as a side effect of _buildRpRarRule. Enforcement treats any
+# RAR request for such an RP as denied.
+has rpRarBroken => (
+    is      => 'rw',
+    default => sub { {} },
+);
+
 sub init {
     my ($self) = @_;
     return unless $self->SUPER::init;
@@ -88,13 +96,24 @@ sub _buildRpAllowedTypes {
 sub _buildRpRarRule {
     my ($self) = @_;
     my %compiled;
-    my $opts  = $self->conf->{oidcRPMetaDataOptions}              || {};
-    my $rules = $self->conf->{oidcRPMetaDataAuthorizationDetailsRules} || {};
+    my $opts = $self->conf->{oidcRPMetaDataOptions} || {};
     for my $rp ( keys %$opts ) {
         next
           unless $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsEnabled};
-        my $perType = $rules->{$rp} or next;
-        next unless ref($perType) eq 'HASH' and %$perType;
+        my $raw = $opts->{$rp}->{oidcRPMetaDataOptionsAuthorizationDetailsRules};
+        next unless defined $raw and length $raw;
+
+        my $perType = eval { decode_json($raw) };
+        if ( $@ or ref($perType) ne 'HASH' ) {
+            my $why = $@ || 'not a JSON object';
+            $self->userLogger->error(
+                "RAR: invalid JSON in "
+              . "oidcRPMetaDataOptionsAuthorizationDetailsRules for RP $rp: $why"
+              . " — denying all authorization_details for this RP" );
+            $self->rpRarBroken->{$rp} = 1;
+            next;
+        }
+        next unless %$perType;
 
         for my $type ( keys %$perType ) {
             my $rule = $perType->{$type};
@@ -212,6 +231,12 @@ sub enforceRulesAndStoreOnCode {
     my ( $self, $req, $oidc_request, $rp, $code_payload ) = @_;
 
     my $details = $req->data->{ &SESSION_KEY } or return PE_OK;
+
+    if ( $self->rpRarBroken->{$rp} ) {
+        $self->logger->error( "RAR: denying authorization_details for RP $rp "
+              . "(rules JSON failed to decode at init)" );
+        return PE_ERROR;
+    }
 
     my $rpRules = $self->rpRarRule->{$rp};
     if ( $rpRules and %$rpRules ) {

--- a/plugins/oidc-rar/manager-overrides/rar.json
+++ b/plugins/oidc-rar/manager-overrides/rar.json
@@ -15,11 +15,10 @@
       "default": "",
       "documentation": "RFC 9396 — per-RP allowlist of authorization_details `type` values (comma-separated). Empty = inherit global only."
     },
-    "oidcRPMetaDataAuthorizationDetailsRules": {
-      "type": "keyTextContainer",
-      "keyTest": "^[\\x21\\x23-\\x5B\\x5D-\\x7E]+$",
-      "default": {},
-      "documentation": "RFC 9396 — per-`type` Perl rules. Key: authorization_details `type` identifier (RFC 6749 token charset). Value: Perl expression evaluated when an entry of that type is requested. Receives the user session attributes plus the magic variable `$detail` (full hashref of the entry). Truthy result grants the entry, falsy rejects it. A type that has no rule entry is permitted (subject to the type allowlist)."
+    "oidcRPMetaDataOptionsAuthorizationDetailsRules": {
+      "type": "longtext",
+      "default": "",
+      "documentation": "RFC 9396 — per-`type` Perl rules, encoded as a JSON object `{\"<type>\": \"<perl_expression>\"}`. Key: authorization_details `type` identifier (RFC 6749 token charset). Value: Perl expression evaluated when an entry of that type is requested. Receives the user session attributes plus the magic variable `$detail` (full hashref of the entry). Truthy result grants the entry, falsy rejects it. A type that has no rule entry is permitted (subject to the type allowlist). Empty string = no rules."
     }
   },
   "tree": [
@@ -31,23 +30,15 @@
     }
   ],
   "ctrees": {
-    "oidcRPMetaDataNode": [
-      {
-        "insert_into": "oidcRPMetaDataOptions/security",
-        "insert_after": "oidcRPMetaDataOptionsRequirePKCE",
-        "nodes": [
-          "oidcRPMetaDataOptionsAuthorizationDetailsEnabled",
-          "oidcRPMetaDataOptionsAuthorizationDetailsTypes"
-        ]
-      },
-      {
-        "insert_into": "oidcRPMetaDataOptions/oidcRPMetaDataOptionsScopes",
-        "insert_after": "oidcRPMetaDataScopeRules",
-        "nodes": [
-          "oidcRPMetaDataAuthorizationDetailsRules"
-        ]
-      }
-    ]
+    "oidcRPMetaDataNode": {
+      "insert_into": "oidcRPMetaDataOptions/security",
+      "insert_after": "oidcRPMetaDataOptionsRequirePKCE",
+      "nodes": [
+        "oidcRPMetaDataOptionsAuthorizationDetailsEnabled",
+        "oidcRPMetaDataOptionsAuthorizationDetailsTypes",
+        "oidcRPMetaDataOptionsAuthorizationDetailsRules"
+      ]
+    }
   },
   "lang": {
     "oidcServiceAuthorizationDetailsTypes": {
@@ -62,9 +53,9 @@
       "en": "RAR — allowed types for this RP",
       "fr": "RAR — types autorisés pour ce RP"
     },
-    "oidcRPMetaDataAuthorizationDetailsRules": {
-      "en": "RAR — Authorization details rules",
-      "fr": "RAR — Règles des détails d'autorisation"
+    "oidcRPMetaDataOptionsAuthorizationDetailsRules": {
+      "en": "RAR — Authorization details rules (JSON: type → Perl expr)",
+      "fr": "RAR — Règles des détails d'autorisation (JSON : type → expr. Perl)"
     }
   }
 }

--- a/plugins/oidc-rar/t/35-OIDC-RAR.t
+++ b/plugins/oidc-rar/t/35-OIDC-RAR.t
@@ -438,6 +438,9 @@ sub op {
                         oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
                         oidcRPMetaDataOptionsAuthorizationDetailsTypes =>
                           'payment_initiation',
+                        # Only allow payments up to 50 EUR
+                        oidcRPMetaDataOptionsAuthorizationDetailsRules =>
+                          '{"payment_initiation": "$detail->{instructedAmount}->{amount} <= 50"}',
                     },
                     rp_norar => {
                         oidcRPMetaDataOptionsDisplayName            => "RP NoRAR",
@@ -460,19 +463,9 @@ sub op {
                         oidcRPMetaDataOptionsAccessTokenExpiration  => 3600,
                         oidcRPMetaDataOptionsRedirectUris           => 'http://rp.com/',
                         oidcRPMetaDataOptionsAuthorizationDetailsEnabled => 1,
-                    },
-                },
-                # Per-RP, per-type Perl rules (oidcRPMetaDataAuthorizationDetailsRules
-                # is a top-level keyTextContainer, like oidcRPMetaDataScopeRules).
-                oidcRPMetaDataAuthorizationDetailsRules => {
-                    rp_strict => {
-                        # Only allow payments up to 50 EUR
-                        payment_initiation =>
-                          '$detail->{instructedAmount}->{amount} <= 50',
-                    },
-                    rp_badrule => {
                         # Syntactically broken Perl: must trigger fail-closed
-                        payment_initiation => 'this is not valid perl ((',
+                        oidcRPMetaDataOptionsAuthorizationDetailsRules =>
+                          '{"payment_initiation": "this is not valid perl (("}',
                     },
                 },
                 oidcServicePrivateKeySig => oidc_key_op_private_sig,


### PR DESCRIPTION
## Summary

- `oidcRPMetaDataAuthorizationDetailsRules` was declared as a `keyTextContainer` at RP level (top-level hash key). That namespace is reserved for core's CTree wiring (`Build.pm:291`).
- Plugin-declared containers there land in `\$oidcRPMetaDataNodeKeys` but stay out of `\$hashParameters`. Serializer then stores / reads them as raw strings, so `\$conf->{oidcRPMetaDataAuthorizationDetailsRules}->{\$rp}->{\$type}` returns `undef` at runtime — silent data loss.
- Replace with `oidcRPMetaDataOptionsAuthorizationDetailsRules`: a `longtext` scalar under `oidcRPMetaDataOptions/security` holding a JSON object `{type → Perl expression}`. The plugin JSON-decodes once at init in `_buildRpRarRule`.

## Fail-closed semantics

- **Invalid JSON at init** → log the error and mark the RP via the new `rpRarBroken` attribute. `enforceRulesAndStoreOnCode` denies any `authorization_details` on that RP.
- **Uncompilable Perl rule for a type** → same per-type deny-all closure as before.

## Why this matters

This PR is one of the offenders fixed alongside #24 (validation that rejects this anti-pattern in `llng-build-manager-files`). #24 will fail the build for this plugin until this PR (and oidc-resource-indicators) land.

## Test plan

- [x] \`mcp/cli.js test oidc-rar\` — all 23 subtests pass, including the broken-Perl-rule fail-closed.
- [x] JSON example in README + OIDC.md updated to the new shape.
- [ ] Post-merge: docker rebuild surfaces no warning + manager can save / reload an RP with this option set.