### PR TITLE
feat(krb-provisioning): add on-the-fly Kerberos provisioning plugin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
     outputs:
       matrix: ${{ steps.find.outputs.matrix }}
       has_tests: ${{ steps.find.outputs.has_tests }}
+      container_matrix: ${{ steps.find.outputs.container_matrix }}
+      has_container_tests: ${{ steps.find.outputs.has_container_tests }}
     steps:
       - uses: actions/checkout@v5
 
@@ -39,10 +41,14 @@ jobs:
           }
 
           entries=()
+          container_entries=()
           for d in plugins/*/; do
             [ -d "$d/t" ] || continue
             name=$(basename "$d")
             compat=$(jq -r '.llng_compat // ""' "$d/plugin.json")
+            # Optional: run this plugin's tests inside a container image (e.g.
+            # a Debian image carrying a dependency Ubuntu runners lack).
+            container=$(jq -r '.ci_container // ""' "$d/plugin.json")
 
             min=$(echo "$compat" | grep -oE '>=\s*[0-9.]+' \
                     | grep -oE '[0-9.]+' | head -1 || true)
@@ -79,21 +85,35 @@ jobs:
 
             for r in "${refs[@]}"; do
               label="${r:-main}"
-              entries+=("{\"plugin\":\"$name\",\"ref\":\"$r\",\"label\":\"$label\"}")
+              if [ -n "$container" ]; then
+                container_entries+=("{\"plugin\":\"$name\",\"ref\":\"$r\",\"label\":\"$label\",\"container\":\"$container\"}")
+              else
+                entries+=("{\"plugin\":\"$name\",\"ref\":\"$r\",\"label\":\"$label\"}")
+              fi
             done
           done
 
           if [ ${#entries[@]} -eq 0 ]; then
             echo "has_tests=false" >> "$GITHUB_OUTPUT"
             echo "matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
-            exit 0
+          else
+            include="[$(IFS=,; echo "${entries[*]}")]"
+            echo "has_tests=true" >> "$GITHUB_OUTPUT"
+            echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
+            echo "Host matrix:"
+            echo "$include" | jq .
           fi
 
-          include="[$(IFS=,; echo "${entries[*]}")]"
-          echo "has_tests=true" >> "$GITHUB_OUTPUT"
-          echo "matrix={\"include\":$include}" >> "$GITHUB_OUTPUT"
-          echo "Matrix:"
-          echo "$include" | jq .
+          if [ ${#container_entries[@]} -eq 0 ]; then
+            echo "has_container_tests=false" >> "$GITHUB_OUTPUT"
+            echo "container_matrix={\"include\":[]}" >> "$GITHUB_OUTPUT"
+          else
+            cinclude="[$(IFS=,; echo "${container_entries[*]}")]"
+            echo "has_container_tests=true" >> "$GITHUB_OUTPUT"
+            echo "container_matrix={\"include\":$cinclude}" >> "$GITHUB_OUTPUT"
+            echo "Container matrix:"
+            echo "$cinclude" | jq .
+          fi
 
   test:
     needs: discover
@@ -106,7 +126,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -141,6 +161,60 @@ jobs:
       - name: Run tests
         run: ./mcp/cli.js execute "${{ matrix.plugin }}"
 
+  # Same as `test`, but for plugins that declare `ci_container` in plugin.json
+  # (e.g. a Debian image carrying a build dependency the Ubuntu runners lack).
+  # Steps run as root inside the container, so no `sudo`, and the base tools the
+  # host runner provides (git, jq, node, perl, make) are installed first.
+  test-container:
+    needs: discover
+    if: needs.discover.outputs.has_container_tests == 'true'
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
+    name: ${{ matrix.plugin }} @ ${{ matrix.label }} (${{ matrix.container }})
+    strategy:
+      matrix: ${{ fromJson(needs.discover.outputs.container_matrix) }}
+      fail-fast: false
+    steps:
+      # Install the tooling the host runner ships with but a minimal Debian
+      # image does not (git is needed before checkout can clone).
+      - name: Install container prerequisites
+        run: |
+          apt-get update
+          apt-get install -y --no-install-recommends \
+            git jq curl ca-certificates build-essential \
+            devscripts equivs perl nodejs npm
+
+      - uses: actions/checkout@v5
+
+      - name: Install MCP/CLI dependencies
+        run: cd mcp && npm install --no-audit --no-fund
+
+      - name: Prepare plugin (clone LLNG + make common + symlinks)
+        run: |
+          REF="${{ matrix.ref }}"
+          if [ -n "$REF" ]; then
+            ./mcp/cli.js prepare "${{ matrix.plugin }}" --ref "$REF"
+          else
+            ./mcp/cli.js prepare "${{ matrix.plugin }}"
+          fi
+
+      - name: Install LLNG build dependencies
+        run: |
+          cd .llng-test/lemonldap-ng
+          mk-build-deps -i -t 'apt-get -y --no-install-recommends' debian/control
+
+      - name: Install plugin extra build dependencies
+        run: |
+          PLUGIN_DIR="plugins/${{ matrix.plugin }}"
+          BUILD_DEPS=$(jq -r '.build_depends // [] | .[]' "$PLUGIN_DIR/plugin.json")
+          if [ -n "$BUILD_DEPS" ]; then
+            echo "Installing extra build deps: $BUILD_DEPS"
+            apt-get install -y --no-install-recommends $BUILD_DEPS
+          fi
+
+      - name: Run tests
+        run: ./mcp/cli.js execute "${{ matrix.plugin }}"
+
   # Global lint: aggregate every plugin's manager-overrides/*.json under a
   # single directory and run llng-build-manager-files against the union.
   # Catches cross-plugin issues that per-plugin jobs miss because they only
@@ -154,7 +228,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,6 +238,22 @@ cd mcp && npm install --no-audit --no-fund
 Exit code from `prove` propagates all the way up, so a failing test
 fails the job.
 
+By default jobs run directly on the `ubuntu-latest` runner. A plugin
+that needs a dependency the Ubuntu runner lacks can set
+`plugin.json:ci_container` to a container image (e.g. `"debian:trixie"`);
+its matrix is then routed to a separate job that runs the same steps
+inside that container. Example — `krb-provisioning` needs
+`libauthen-krb5-admin-perl`, which is absent from Ubuntu 24.04 but present
+on Debian:
+
+```json
+{
+  "name": "krb-provisioning",
+  "build_depends": ["libauthen-krb5-admin-perl"],
+  "ci_container": "debian:trixie"
+}
+```
+
 ## Environment overrides
 
 | Variable            | Default                                                |

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The Manager rebuild is triggered only once via dpkg triggers, even when installi
 | [json-file](plugins/json-file)                               | JSON file-based Auth/UserDB backend for dev/test           | stable |
 | [pam-access](plugins/pam-access)                             | PAM access token generation and authorization for SSH/sudo | beta   |
 | [ssh-ca](plugins/ssh-ca)                                     | SSH Certificate Authority                                  | beta   |
+| [krb-provisioning](plugins/krb-provisioning)                 | On-the-fly Kerberos principal provisioning from SSO logins | alpha  |
 | [twake](plugins/twake)                                       | Twake well-known endpoint and applicative accounts         | beta   |
 | [fixed-logout-redirection](plugins/fixed-logout-redirection) | Force redirect to a fixed URL after logout                 | beta   |
 | [external-menu](plugins/external-menu)                       | Redirect authenticated users to an external menu URL       | beta   |

--- a/plugins/krb-provisioning/README.md
+++ b/plugins/krb-provisioning/README.md
@@ -20,8 +20,9 @@ project and a separate reconciliation job.
 
 ## Features
 
-- **`endAuth` hook** — runs after a successful authentication, while the
-  cleartext password is still available on the request.
+- **`betweenAuthAndData` hook** — runs right after the password is validated
+  and **before** the second-factor gate, while the cleartext password is still
+  on the request. This is deliberately *not* `endAuth`: see [MFA](#mfa) below.
 - **Idempotent** — creates the principal on first login (`addprinc`), and
   resets its key on every subsequent login (`cpw`) to absorb password drift
   in the general directory.
@@ -82,6 +83,27 @@ ignored.
 > **Note:** do not enable `storePassword` for this plugin. The password is only
 > needed transiently, in memory, for the duration of the kadmin call.
 
+## MFA
+
+With multi-factor authentication, the OTP is submitted in a **second** request
+that carries no password and only re-runs `buildCookie` + `endAuth`. Hooking
+`endAuth` would therefore see an empty `$req->data->{password}` and never
+provision MFA users. The plugin hooks `betweenAuthAndData` instead, which runs
+on the **credentials** request, right after the password is validated and
+before the second-factor gate — so provisioning happens exactly once, with the
+password, regardless of whether a second factor follows.
+
+Consequence: the Kerberos key is set as soon as the password is validated,
+even if the user later fails or abandons the second factor. This is consistent
+with Kerberos itself, which is single-factor by design and cannot enforce the
+SSO's OTP at `kinit` time — the password was genuinely validated against the
+directory, which is the guarantee that matters for setting the key.
+
+Because the principal is resolved this early, `krbPrincipalAttribute` must name
+an attribute already populated by the UserDB at `getUser` time. When empty (the
+default) or when the attribute is not yet available, the login (`REMOTE_USER`)
+is used.
+
 ## Acceptance criteria
 
 1. First login of a known user → principal `<uid>@REALM` created; `kinit`
@@ -101,5 +123,7 @@ ignored.
 ```
 
 The test suite mocks the kadmind backend (no real KDC needed) and covers the
-mapping, the no-op paths, the non-blocking guarantee, and the
-password-never-logged / never-in-argv constraints.
+mapping, the no-op paths, the non-blocking guarantee, the
+password-never-logged / never-in-argv constraints, and an **MFA** scenario
+(external 2F) proving the principal is provisioned on the credentials request
+and not lost across the OTP step.

--- a/plugins/krb-provisioning/README.md
+++ b/plugins/krb-provisioning/README.md
@@ -26,8 +26,11 @@ project and a separate reconciliation job.
 - **Idempotent** — creates the principal on first login (`addprinc`), and
   resets its key on every subsequent login (`cpw`) to absorb password drift
   in the general directory.
-- **Strictly non-blocking** — any kadmind error is logged and swallowed; the
-  SSO authentication always succeeds.
+- **Strictly non-blocking, with a hard timeout** — any kadmind error is logged
+  and swallowed; the SSO authentication always returns `PE_OK`. The whole
+  kadmind operation runs in a forked child bounded by `krbConnectTimeout`
+  (default **5 s**): an unresponsive kadmind — or the Kerberos LDAP behind it —
+  is SIGKILLed after that delay and can never delay, let alone block, the login.
 - **Silent no-op without a cleartext password** — cookie SSO, SAML/OIDC
   federation, SPNEGO: nothing to provision, no kadmin call.
 - **Password never leaks** — it is used in memory only, never logged, and
@@ -72,7 +75,7 @@ provisioning**:
 | `krbPrincipalAttribute`     | Session attribute holding the principal name (empty = login) | _(login)_    |
 | `krbPrincipalFormat`        | `sprintf` template applied to `(login, realm)`               | `%s@%s`      |
 | `krbDefaultPolicy`          | Kerberos policy applied to created principals (optional)     | _(empty)_    |
-| `krbConnectTimeout`         | kadmind connection/command timeout in seconds                | `3`          |
+| `krbConnectTimeout`         | Hard time budget (seconds) for the whole kadmind operation   | `5`          |
 
 The mapping is `principal = sprintf(krbPrincipalFormat, login, krbRealm)`,
 where `login` is `krbPrincipalAttribute` from the session, or the login
@@ -111,8 +114,9 @@ is used.
 2. Repeated login → no error, `kinit` keeps working (idempotent `cpw`).
 3. Password changed in the general directory, then new SSO login → `kinit`
    succeeds with the **new** password (resync).
-4. `kadmind` down during a login → SSO **still succeeds** (failure logged,
-   non-blocking).
+4. `kadmind` down or **unresponsive** during a login → SSO **still succeeds**,
+   and the login is never delayed more than `krbConnectTimeout` (failure
+   logged, non-blocking).
 5. Cookie SSO (no re-entry) → no kadmin call.
 6. The password appears in no log and in no `/proc` entry.
 
@@ -123,7 +127,12 @@ is used.
 ```
 
 The test suite mocks the kadmind backend (no real KDC needed) and covers the
-mapping, the no-op paths, the non-blocking guarantee, the
-password-never-logged / never-in-argv constraints, and an **MFA** scenario
-(external 2F) proving the principal is provisioned on the credentials request
-and not lost across the OTP step.
+mapping, the no-op paths, the non-blocking guarantee, the hard timeout (a
+hanging backend returns `PE_OK` promptly), the password-never-logged /
+never-in-argv constraints, and an **MFA** scenario (external 2F) proving the
+principal is provisioned on the credentials request and not lost across the
+OTP step.
+
+## License
+
+AGPL-3.0.

--- a/plugins/krb-provisioning/README.md
+++ b/plugins/krb-provisioning/README.md
@@ -34,17 +34,20 @@ project and a separate reconciliation job.
 - **Silent no-op without a cleartext password** — cookie SSO, SAML/OIDC
   federation, SPNEGO: nothing to provision, no kadmin call.
 - **Password never leaks** — it is used in memory only, never logged, and
-  never passed as a command-line argument (no `-pw`, cf. `/proc/<pid>/cmdline`).
-- **Two backends** — [`Authen::Krb5::Admin`](https://metacpan.org/pod/Authen::Krb5::Admin)
-  (in-memory `libkadm5` bindings) when available, otherwise a fallback that
-  shells to `kadmin` and feeds the password on **stdin**, with a short timeout.
+  never passed as a command-line argument: the key is set through the
+  `libkadm5` bindings in process, so it never reaches a shell or `/proc`.
+- **In-memory `libkadm5` backend** — uses
+  [`Authen::Krb5::Admin`](https://metacpan.org/pod/Authen::Krb5::Admin)
+  exclusively. The module is a hard requirement; `init` disables the plugin
+  (with a clear log) if it is missing rather than failing silently per login.
 
 ## Requirements
 
 - LemonLDAP::NG >= 2.23.0
+- **`Authen::Krb5::Admin`** — Debian: `libauthen-krb5-admin-perl`
+  (declared as a dependency; installed automatically with the package).
 - A reachable `kadmind`, a service principal (e.g. `lemonldap/admin@REALM`)
   and its keytab, readable only by the portal process.
-- `Authen::Krb5::Admin` _(recommended)_, or the `kadmin` client in `PATH`.
 - The KDC's `kadm5.acl` must grant the service principal **only** `add`,
   `changepw` and `modify` (no `delete`, no `*`).
 
@@ -127,11 +130,12 @@ is used.
 ```
 
 The test suite mocks the kadmind backend (no real KDC needed) and covers the
-mapping, the no-op paths, the non-blocking guarantee, the hard timeout (a
-hanging backend returns `PE_OK` promptly), the password-never-logged /
-never-in-argv constraints, and an **MFA** scenario (external 2F) proving the
-principal is provisioned on the credentials request and not lost across the
-OTP step.
+mapping (including rejection of injection-prone logins), the no-op paths, the
+non-blocking guarantee, the hard timeout (a hanging backend returns `PE_OK`
+promptly), the password-never-logged constraint, and an **MFA** scenario
+(external 2F) proving the principal is provisioned on the credentials request
+and not lost across the OTP step. The tests skip when `Authen::Krb5::Admin` is
+not installed.
 
 ## License
 

--- a/plugins/krb-provisioning/README.md
+++ b/plugins/krb-provisioning/README.md
@@ -1,0 +1,105 @@
+# Kerberos provisioning - on-the-fly KDC principal sync
+
+This plugin provisions and resynchronizes a user's Kerberos principal **at
+each real login**, using the cleartext password that LemonLDAP::NG already
+holds while validating the user against the general directory.
+
+## Why
+
+A dedicated MIT KDC keeps its principals in a separate, autonomous OpenLDAP
+base. Kerberos cannot delegate authentication to the general identity
+directory at `kinit` time: the KDC needs the **key derived from the password**
+already present in its base. That key can only be built when someone sees the
+cleartext password — and the SSO login is exactly that moment.
+
+On every password-based login, this plugin sets (or resets) the user's
+Kerberos key equal to their current password, so they can then obtain tickets
+(`kinit` / Kerberos SSO) against the KDC. It does **not** manage the KDC, the
+realm, the `krbContainer`, or deprovisioning — those belong to the `pure-kdc`
+project and a separate reconciliation job.
+
+## Features
+
+- **`endAuth` hook** — runs after a successful authentication, while the
+  cleartext password is still available on the request.
+- **Idempotent** — creates the principal on first login (`addprinc`), and
+  resets its key on every subsequent login (`cpw`) to absorb password drift
+  in the general directory.
+- **Strictly non-blocking** — any kadmind error is logged and swallowed; the
+  SSO authentication always succeeds.
+- **Silent no-op without a cleartext password** — cookie SSO, SAML/OIDC
+  federation, SPNEGO: nothing to provision, no kadmin call.
+- **Password never leaks** — it is used in memory only, never logged, and
+  never passed as a command-line argument (no `-pw`, cf. `/proc/<pid>/cmdline`).
+- **Two backends** — [`Authen::Krb5::Admin`](https://metacpan.org/pod/Authen::Krb5::Admin)
+  (in-memory `libkadm5` bindings) when available, otherwise a fallback that
+  shells to `kadmin` and feeds the password on **stdin**, with a short timeout.
+
+## Requirements
+
+- LemonLDAP::NG >= 2.23.0
+- A reachable `kadmind`, a service principal (e.g. `lemonldap/admin@REALM`)
+  and its keytab, readable only by the portal process.
+- `Authen::Krb5::Admin` _(recommended)_, or the `kadmin` client in `PATH`.
+- The KDC's `kadm5.acl` must grant the service principal **only** `add`,
+  `changepw` and `modify` (no `delete`, no `*`).
+
+## Installation
+
+With `lemonldap-ng-store` _(LLNG >= 2.24.0)_ or [linagora-lemonldap-ng-store](../../README.md#installation-with-debian-packages):
+
+```bash
+sudo lemonldap-ng-store install krb-provisioning
+```
+
+Manually: copy `lib/` into your Perl `@INC` path, copy `manager-overrides/`
+into `/etc/lemonldap-ng/manager-overrides.d/`, add `::Plugins::KrbProvisioning`
+to `customPlugins`, and run `llng-build-manager-files`.
+
+## Configuration
+
+In the Manager under **General Parameters** > **Plugins** > **Kerberos
+provisioning**:
+
+| Parameter                   | Description                                                          | Default      |
+| --------------------------- | -------------------------------------------------------------------- | ------------ |
+| `krbProvisioningActivation` | Enable the plugin                                                    | `0`          |
+| `krbRealm`                  | Kerberos realm of the provisioned principals                        | _(required)_ |
+| `krbAdminServer`            | `kadmind` server as `host[:port]`                                    | _(required)_ |
+| `krbServicePrincipal`       | Service principal used to authenticate to kadmind                    | _(required)_ |
+| `krbKeytab`                 | Path to the service principal's keytab                              | _(required)_ |
+| `krbPrincipalAttribute`     | Session attribute holding the principal name (empty = login)         | _(login)_    |
+| `krbPrincipalFormat`        | `sprintf` template applied to `(login, realm)`                       | `%s@%s`      |
+| `krbDefaultPolicy`          | Kerberos policy applied to created principals (optional)             | _(empty)_    |
+| `krbConnectTimeout`         | kadmind connection/command timeout in seconds                        | `3`          |
+
+The mapping is `principal = sprintf(krbPrincipalFormat, login, krbRealm)`,
+where `login` is `krbPrincipalAttribute` from the session, or the login
+(`REMOTE_USER`) when that parameter is empty. Logins that are empty or contain
+characters invalid in a principal component (whitespace, `@`, `/`, NUL) are
+ignored.
+
+> **Note:** do not enable `storePassword` for this plugin. The password is only
+> needed transiently, in memory, for the duration of the kadmin call.
+
+## Acceptance criteria
+
+1. First login of a known user → principal `<uid>@REALM` created; `kinit`
+   succeeds with that password.
+2. Repeated login → no error, `kinit` keeps working (idempotent `cpw`).
+3. Password changed in the general directory, then new SSO login → `kinit`
+   succeeds with the **new** password (resync).
+4. `kadmind` down during a login → SSO **still succeeds** (failure logged,
+   non-blocking).
+5. Cookie SSO (no re-entry) → no kadmin call.
+6. The password appears in no log and in no `/proc` entry.
+
+## Testing
+
+```bash
+./mcp/cli.js test krb-provisioning
+```
+
+The test suite mocks the kadmind backend (no real KDC needed) and covers the
+mapping, the no-op paths, the non-blocking guarantee, and the
+password-never-logged / never-in-argv constraints.

--- a/plugins/krb-provisioning/README.md
+++ b/plugins/krb-provisioning/README.md
@@ -22,7 +22,7 @@ project and a separate reconciliation job.
 
 - **`betweenAuthAndData` hook** — runs right after the password is validated
   and **before** the second-factor gate, while the cleartext password is still
-  on the request. This is deliberately *not* `endAuth`: see [MFA](#mfa) below.
+  on the request. This is deliberately _not_ `endAuth`: see [MFA](#mfa) below.
 - **Idempotent** — creates the principal on first login (`addprinc`), and
   resets its key on every subsequent login (`cpw`) to absorb password drift
   in the general directory.
@@ -62,17 +62,17 @@ to `customPlugins`, and run `llng-build-manager-files`.
 In the Manager under **General Parameters** > **Plugins** > **Kerberos
 provisioning**:
 
-| Parameter                   | Description                                                          | Default      |
-| --------------------------- | -------------------------------------------------------------------- | ------------ |
-| `krbProvisioningActivation` | Enable the plugin                                                    | `0`          |
-| `krbRealm`                  | Kerberos realm of the provisioned principals                        | _(required)_ |
-| `krbAdminServer`            | `kadmind` server as `host[:port]`                                    | _(required)_ |
-| `krbServicePrincipal`       | Service principal used to authenticate to kadmind                    | _(required)_ |
-| `krbKeytab`                 | Path to the service principal's keytab                              | _(required)_ |
-| `krbPrincipalAttribute`     | Session attribute holding the principal name (empty = login)         | _(login)_    |
-| `krbPrincipalFormat`        | `sprintf` template applied to `(login, realm)`                       | `%s@%s`      |
-| `krbDefaultPolicy`          | Kerberos policy applied to created principals (optional)             | _(empty)_    |
-| `krbConnectTimeout`         | kadmind connection/command timeout in seconds                        | `3`          |
+| Parameter                   | Description                                                  | Default      |
+| --------------------------- | ------------------------------------------------------------ | ------------ |
+| `krbProvisioningActivation` | Enable the plugin                                            | `0`          |
+| `krbRealm`                  | Kerberos realm of the provisioned principals                 | _(required)_ |
+| `krbAdminServer`            | `kadmind` server as `host[:port]`                            | _(required)_ |
+| `krbServicePrincipal`       | Service principal used to authenticate to kadmind            | _(required)_ |
+| `krbKeytab`                 | Path to the service principal's keytab                       | _(required)_ |
+| `krbPrincipalAttribute`     | Session attribute holding the principal name (empty = login) | _(login)_    |
+| `krbPrincipalFormat`        | `sprintf` template applied to `(login, realm)`               | `%s@%s`      |
+| `krbDefaultPolicy`          | Kerberos policy applied to created principals (optional)     | _(empty)_    |
+| `krbConnectTimeout`         | kadmind connection/command timeout in seconds                | `3`          |
 
 The mapping is `principal = sprintf(krbPrincipalFormat, login, krbRealm)`,
 where `login` is `krbPrincipalAttribute` from the session, or the login

--- a/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
+++ b/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
@@ -16,10 +16,10 @@
 # there is no cleartext password (SSO cookie reuse, SAML/OIDC/SPNEGO
 # federation) it is a silent no-op.
 #
-# Two kadmind backends, by order of preference:
-#   1. Authen::Krb5::Admin (libkadm5 bindings) -> in-memory, no shell, no leak.
-#   2. Fallback: shell out to `kadmin -k -t <keytab> -p <principal>` feeding the
-#      password on STDIN. The password is NEVER passed as an argv argument.
+# kadmind is reached through Authen::Krb5::Admin (libkadm5 bindings): the key is
+# set in memory, no shell, no password on any command line. The module is a hard
+# requirement (Debian: libauthen-krb5-admin-perl) -- init() refuses to load the
+# plugin if it is missing.
 #
 # See SPEC: docs/llng-kerberos-provisioning-plugin.md (pure-kdc project).
 
@@ -42,30 +42,19 @@ use constant name => 'KrbProvisioning';
 # preferred over endAuth (MFA compatibility).
 use constant betweenAuthAndData => 'provision';
 
-# Whether the Authen::Krb5::Admin bindings are available. Resolved lazily and
-# only once: if present we use the in-memory API, otherwise we shell to kadmin.
-has _krb5AdminAvailable => (
-    is      => 'rw',
-    lazy    => 1,
-    default => sub {
-        my ($self) = @_;
-        my $ok = eval {
-            require Authen::Krb5;
-            require Authen::Krb5::Admin;
-            1;
-        };
-        unless ($ok) {
-            $self->logger->info( 'KrbProvisioning: Authen::Krb5::Admin not '
-                  . 'available, falling back to the kadmin command' );
-        }
-        return $ok ? 1 : 0;
-    },
-);
-
 # INITIALIZATION
 
 sub init {
     my ($self) = @_;
+
+    # Hard dependency: without Authen::Krb5::Admin the plugin cannot do anything,
+    # so refuse to load with a clear message rather than failing silently at
+    # every login.
+    unless ( eval { require Authen::Krb5; require Authen::Krb5::Admin; 1 } ) {
+        $self->logger->error( 'KrbProvisioning requires Authen::Krb5::Admin '
+              . '(Debian: libauthen-krb5-admin-perl); plugin disabled' );
+        return 0;
+    }
 
     # Required parameters: without them the plugin cannot reach kadmind.
     for my $key (qw(krbRealm krbAdminServer krbServicePrincipal krbKeytab)) {
@@ -145,12 +134,10 @@ sub _principalFor {
     return undef unless defined $login && length $login;
 
     # Strict allowlist rather than a blocklist: a login becomes a Kerberos
-    # principal component and, in the kadmin fallback, is interpolated into a
-    # quoted `-q` query string. Only accept characters that are unambiguous
-    # there -- letters, digits, dot, underscore, hyphen, plus a trailing '$'
-    # for machine accounts. This rejects whitespace, '@', '/', NUL, quotes,
-    # backslashes and any control/metacharacter that could break or inject the
-    # query.
+    # principal component. Only accept characters that are unambiguous there --
+    # letters, digits, dot, underscore, hyphen, plus a trailing '$' for machine
+    # accounts. This rejects whitespace, '@', '/', NUL, quotes, backslashes and
+    # any control/metacharacter that has no business in a principal name.
     return undef unless $login =~ /\A[A-Za-z0-9._-]+\$?\z/;
 
     my $fmt = $self->conf->{krbPrincipalFormat} || '%s@%s';
@@ -191,7 +178,7 @@ sub _setKerberosPassword {
         POSIX::setsid();
         my $rc = 0;
         eval {
-            $self->_dispatchBackend( $princ, $pwd );
+            $self->_setViaKrb5Admin( $princ, $pwd );
             1;
         } or do {
             my $e = $@ || 'unknown error';
@@ -235,16 +222,7 @@ sub _setKerberosPassword {
     return 1;
 }
 
-sub _dispatchBackend {
-    my ( $self, $princ, $pwd ) = @_;
-
-    if ( $self->_krb5AdminAvailable ) {
-        return $self->_setViaKrb5Admin( $princ, $pwd );
-    }
-    return $self->_setViaShell( $princ, $pwd );
-}
-
-# Preferred backend: Authen::Krb5::Admin (libkadm5), entirely in memory.
+# kadmind backend: Authen::Krb5::Admin (libkadm5), entirely in memory.
 sub _setViaKrb5Admin {
     my ( $self, $princ, $pwd ) = @_;
 
@@ -303,107 +281,6 @@ sub _setViaKrb5Admin {
     }
 
     return 1;
-}
-
-# Fallback backend: drive the kadmin command, feeding the password on STDIN.
-# The password is never present in the argv (cf. /proc/<pid>/cmdline).
-sub _setViaShell {
-    my ( $self, $princ, $pwd ) = @_;
-
-    # Strip the realm: kadmin commands take the bare principal, the realm is
-    # already provided with -r.
-    ( my $shortPrinc = $princ ) =~ s/\@.*$//;
-
-    # 1. Existence check (no password involved).
-    my ( $exists, undef ) =
-      $self->_runKadmin( "getprinc -terse \"$shortPrinc\"", undef );
-
-    # Feed the password twice (kadmin prompts for confirmation), on STDIN only.
-    my $stdin = "$pwd\n$pwd\n";
-
-    if ($exists) {
-        my ($ok) = $self->_runKadmin( "cpw \"$shortPrinc\"", $stdin );
-        die "kadmin cpw returned a non-zero status\n" unless $ok;
-        $self->logger->debug("KrbProvisioning: cpw $princ (resync)");
-    }
-    else {
-        my $policy = $self->conf->{krbDefaultPolicy};
-        my $query =
-          ( defined $policy && length $policy )
-          ? "addprinc -policy \"$policy\" \"$shortPrinc\""
-          : "addprinc \"$shortPrinc\"";
-        my ($ok) = $self->_runKadmin( $query, $stdin );
-        die "kadmin addprinc returned a non-zero status\n" unless $ok;
-        $self->userLogger->info(
-            "KrbProvisioning: created Kerberos principal $princ");
-    }
-
-    return 1;
-}
-
-# Base kadmin argv, WITHOUT any password. Exposed as a method so the test suite
-# can assert the password never appears on the command line.
-sub _kadminBaseArgv {
-    my ($self) = @_;
-    return (
-        'kadmin',
-        '-k',
-        '-t', $self->conf->{krbKeytab},
-        '-p', $self->conf->{krbServicePrincipal},
-        '-r', $self->conf->{krbRealm},
-        '-s', $self->conf->{krbAdminServer},
-    );
-}
-
-# Run a single kadmin query, optionally feeding $stdin to the child process,
-# with a short timeout. Returns (success_bool, captured_output).
-sub _runKadmin {
-    my ( $self, $query, $stdin ) = @_;
-
-    require IPC::Open3;
-    require Symbol;
-
-    my @cmd = ( $self->_kadminBaseArgv, '-q', $query );
-    my $timeout = $self->conf->{krbConnectTimeout} || 5;
-
-    my ( $wtr, $rdr, $err );
-    $err = Symbol::gensym();
-
-    my $output = '';
-    my $pid;
-    my $ok = eval {
-        local $SIG{ALRM} = sub { die "timeout\n" };
-        alarm $timeout;
-
-        $pid = IPC::Open3::open3( $wtr, $rdr, $err, @cmd );
-
-        if ( defined $stdin ) {
-            print {$wtr} $stdin;
-        }
-        close $wtr;
-
-        local $/;
-        $output = <$rdr> // '';
-        $output .= <$err> // '';
-
-        waitpid( $pid, 0 );
-        alarm 0;
-        1;
-    };
-    my $error = $@;
-    alarm 0;
-
-    if ( !$ok ) {
-        # Timeout or spawn failure: reap the child if we have one.
-        if ($pid) {
-            kill 'TERM', $pid;
-            waitpid( $pid, 0 );
-        }
-        die "kadmin call failed: $error";
-    }
-
-    my $status = $?;
-    return ( ( $status == 0 ) ? 1 : 0, $output );
 }
 
 1;

--- a/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
+++ b/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
@@ -1,0 +1,310 @@
+# Kerberos on-the-fly provisioning plugin for LemonLDAP::NG
+#
+# At each *real* login (cleartext password present), this plugin (re)sets the
+# Kerberos key of the user equal to the password just validated by the SSO,
+# by talking to a kadmind service. This lets a dedicated MIT KDC issue tickets
+# (kinit / Kerberos SSO) for users whose identities live in a separate, general
+# LDAP directory that the KDC cannot delegate to at kinit time.
+#
+# It hooks `endAuth` (after a successful authentication, when $req->data->{password}
+# is still populated). It is strictly NON-BLOCKING: any provisioning error is
+# logged but never fails the SSO authentication. When there is no cleartext
+# password (SSO cookie reuse, SAML/OIDC/SPNEGO federation) it is a silent no-op.
+#
+# Two kadmind backends, by order of preference:
+#   1. Authen::Krb5::Admin (libkadm5 bindings) -> in-memory, no shell, no leak.
+#   2. Fallback: shell out to `kadmin -k -t <keytab> -p <principal>` feeding the
+#      password on STDIN. The password is NEVER passed as an argv argument.
+#
+# See SPEC: docs/llng-kerberos-provisioning-plugin.md (pure-kdc project).
+
+package Lemonldap::NG::Portal::Plugins::KrbProvisioning;
+
+use strict;
+use Mouse;
+use Lemonldap::NG::Portal::Main::Constants qw(PE_OK);
+
+our $VERSION = '0.1.0';
+
+extends 'Lemonldap::NG::Portal::Main::Plugin';
+
+use constant name => 'KrbProvisioning';
+
+# Hook: executed at the end of a successful authentication, after the cookie
+# is built. At this stage $req->data->{password} still holds the cleartext
+# password for password-based authentication modules.
+use constant endAuth => 'provision';
+
+# Whether the Authen::Krb5::Admin bindings are available. Resolved lazily and
+# only once: if present we use the in-memory API, otherwise we shell to kadmin.
+has _krb5AdminAvailable => (
+    is      => 'rw',
+    lazy    => 1,
+    default => sub {
+        my ($self) = @_;
+        my $ok = eval {
+            require Authen::Krb5;
+            require Authen::Krb5::Admin;
+            1;
+        };
+        unless ($ok) {
+            $self->logger->info( 'KrbProvisioning: Authen::Krb5::Admin not '
+                  . 'available, falling back to the kadmin command' );
+        }
+        return $ok ? 1 : 0;
+    },
+);
+
+# INITIALIZATION
+
+sub init {
+    my ($self) = @_;
+
+    # Required parameters: without them the plugin cannot reach kadmind.
+    for my $key (qw(krbRealm krbAdminServer krbServicePrincipal krbKeytab)) {
+        unless ( defined $self->conf->{$key} && length $self->conf->{$key} ) {
+            $self->logger->error(
+                "KrbProvisioning: missing required configuration '$key'");
+            return 0;
+        }
+    }
+
+    # The keytab must be readable by the portal process; warn (don't fail) so
+    # that a transient mount issue doesn't disable the whole portal.
+    my $keytab = $self->conf->{krbKeytab};
+    unless ( -r $keytab ) {
+        $self->logger->warn(
+            "KrbProvisioning: keytab '$keytab' is not readable by the portal "
+              . 'process; provisioning will fail until it is' );
+    }
+
+    return 1;
+}
+
+# RUNNING METHOD (endAuth hook)
+
+sub provision {
+    my ( $self, $req ) = @_;
+
+    # Resolve the login used to derive the principal.
+    my $attr = $self->conf->{krbPrincipalAttribute};
+    my $login =
+        ( defined $attr && length $attr )
+      ? $req->{sessionInfo}->{$attr}
+      : $req->{user};
+
+    # Cleartext password. Absent on cookie SSO / federation (SAML, OIDC,
+    # SPNEGO) -> nothing to provision, silent no-op.
+    my $pwd = $req->data->{password};
+    return PE_OK unless defined $pwd && length $pwd;
+
+    unless ( defined $login && length $login ) {
+        $self->logger->debug(
+            'KrbProvisioning: no login available, skipping provisioning');
+        return PE_OK;
+    }
+
+    my $princ = $self->_principalFor($login);
+    unless ( defined $princ ) {
+        $self->logger->debug( "KrbProvisioning: cannot build a valid Kerberos "
+              . "principal from login '$login', skipping" );
+        return PE_OK;
+    }
+
+    # Provision the key. Errors are logged (never the password) and swallowed:
+    # a provisioning failure must NEVER break the SSO authentication.
+    eval {
+        $self->_setKerberosPassword( $princ, $pwd );
+        1;
+    } or do {
+        my $err = $@ || 'unknown error';
+        chomp $err;
+        $self->logger->error(
+            "KrbProvisioning: failed to provision principal $princ: $err");
+    };
+
+    return PE_OK;    # ALWAYS non-blocking
+}
+
+# IDENTITY -> PRINCIPAL MAPPING
+
+# Build the Kerberos principal name from a login, or return undef if the login
+# is empty or holds characters that are invalid in a principal component.
+sub _principalFor {
+    my ( $self, $login ) = @_;
+    return undef unless defined $login && length $login;
+
+    # Reject whitespace, NUL, and the principal separators '@' and '/'. Such a
+    # login can't map to a single principal component and is almost certainly a
+    # spoofed / malformed identity.
+    return undef if $login =~ m{[\s\@/\x00]};
+
+    my $fmt = $self->conf->{krbPrincipalFormat} || '%s@%s';
+    return sprintf( $fmt, $login, $self->conf->{krbRealm} );
+}
+
+# KADMIND BACKEND DISPATCH
+
+sub _setKerberosPassword {
+    my ( $self, $princ, $pwd ) = @_;
+
+    if ( $self->_krb5AdminAvailable ) {
+        return $self->_setViaKrb5Admin( $princ, $pwd );
+    }
+    return $self->_setViaShell( $princ, $pwd );
+}
+
+# Preferred backend: Authen::Krb5::Admin (libkadm5), entirely in memory.
+sub _setViaKrb5Admin {
+    my ( $self, $princ, $pwd ) = @_;
+
+    require Authen::Krb5;
+    require Authen::Krb5::Admin;
+    Authen::Krb5::Admin->import(qw(:constants));
+
+    Authen::Krb5::init_context();
+
+    # Authenticate to kadmind with the service principal via the keytab.
+    my $handle = Authen::Krb5::Admin->init_with_skey(
+        $self->conf->{krbServicePrincipal},
+        $self->conf->{krbKeytab},
+        Authen::Krb5::Admin::KADM5_ADMIN_SERVICE(),
+    ) or die "kadm5 init failed: " . Authen::Krb5::Admin::error() . "\n";
+
+    my $kprinc = Authen::Krb5::parse_name($princ)
+      or die "cannot parse principal $princ\n";
+
+    if ( $handle->get_principal($kprinc) ) {
+
+        # Principal exists -> resync its key on every login.
+        $handle->chpass_principal( $kprinc, $pwd )
+          or die "cpw failed: " . Authen::Krb5::Admin::error() . "\n";
+        $self->logger->debug("KrbProvisioning: cpw $princ (resync)");
+    }
+    else {
+        # Principal missing -> create it with this password.
+        my $pr = Authen::Krb5::Admin::Principal->new;
+        $pr->principal($kprinc);
+        my $policy = $self->conf->{krbDefaultPolicy};
+        if ( defined $policy && length $policy ) {
+            $pr->policy($policy);
+            $handle->create_principal( $pr, $pwd,
+                Authen::Krb5::Admin::KADM5_PRINCIPAL()
+                  | Authen::Krb5::Admin::KADM5_POLICY() )
+              or die "addprinc failed: "
+              . Authen::Krb5::Admin::error() . "\n";
+        }
+        else {
+            $handle->create_principal( $pr, $pwd )
+              or die "addprinc failed: "
+              . Authen::Krb5::Admin::error() . "\n";
+        }
+        $self->userLogger->info(
+            "KrbProvisioning: created Kerberos principal $princ");
+    }
+
+    return 1;
+}
+
+# Fallback backend: drive the kadmin command, feeding the password on STDIN.
+# The password is never present in the argv (cf. /proc/<pid>/cmdline).
+sub _setViaShell {
+    my ( $self, $princ, $pwd ) = @_;
+
+    # Strip the realm: kadmin commands take the bare principal, the realm is
+    # already provided with -r.
+    ( my $shortPrinc = $princ ) =~ s/\@.*$//;
+
+    # 1. Existence check (no password involved).
+    my ( $exists, undef ) =
+      $self->_runKadmin( "getprinc -terse \"$shortPrinc\"", undef );
+
+    # Feed the password twice (kadmin prompts for confirmation), on STDIN only.
+    my $stdin = "$pwd\n$pwd\n";
+
+    if ($exists) {
+        my ($ok) = $self->_runKadmin( "cpw \"$shortPrinc\"", $stdin );
+        die "kadmin cpw returned a non-zero status\n" unless $ok;
+        $self->logger->debug("KrbProvisioning: cpw $princ (resync)");
+    }
+    else {
+        my $policy = $self->conf->{krbDefaultPolicy};
+        my $query =
+          ( defined $policy && length $policy )
+          ? "addprinc -policy \"$policy\" \"$shortPrinc\""
+          : "addprinc \"$shortPrinc\"";
+        my ($ok) = $self->_runKadmin( $query, $stdin );
+        die "kadmin addprinc returned a non-zero status\n" unless $ok;
+        $self->userLogger->info(
+            "KrbProvisioning: created Kerberos principal $princ");
+    }
+
+    return 1;
+}
+
+# Base kadmin argv, WITHOUT any password. Exposed as a method so the test suite
+# can assert the password never appears on the command line.
+sub _kadminBaseArgv {
+    my ($self) = @_;
+    return (
+        'kadmin',
+        '-k',
+        '-t', $self->conf->{krbKeytab},
+        '-p', $self->conf->{krbServicePrincipal},
+        '-r', $self->conf->{krbRealm},
+        '-s', $self->conf->{krbAdminServer},
+    );
+}
+
+# Run a single kadmin query, optionally feeding $stdin to the child process,
+# with a short timeout. Returns (success_bool, captured_output).
+sub _runKadmin {
+    my ( $self, $query, $stdin ) = @_;
+
+    require IPC::Open3;
+    require Symbol;
+
+    my @cmd = ( $self->_kadminBaseArgv, '-q', $query );
+    my $timeout = $self->conf->{krbConnectTimeout} || 3;
+
+    my ( $wtr, $rdr, $err );
+    $err = Symbol::gensym();
+
+    my $output = '';
+    my $pid;
+    my $ok = eval {
+        local $SIG{ALRM} = sub { die "timeout\n" };
+        alarm $timeout;
+
+        $pid = IPC::Open3::open3( $wtr, $rdr, $err, @cmd );
+
+        if ( defined $stdin ) {
+            print {$wtr} $stdin;
+        }
+        close $wtr;
+
+        local $/;
+        $output = <$rdr> // '';
+        $output .= <$err> // '';
+
+        waitpid( $pid, 0 );
+        alarm 0;
+        1;
+    };
+    my $error = $@;
+    alarm 0;
+
+    if ( !$ok ) {
+        # Timeout or spawn failure: reap the child if we have one.
+        if ($pid) {
+            kill 'TERM', $pid;
+            waitpid( $pid, 0 );
+        }
+        die "kadmin call failed: $error";
+    }
+
+    my $status = $?;
+    return ( ( $status == 0 ) ? 1 : 0, $output );
+}
+
+1;

--- a/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
+++ b/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
@@ -155,7 +155,83 @@ sub _principalFor {
 
 # KADMIND BACKEND DISPATCH
 
+# Run the kadmind operation under a hard time budget so that an unresponsive
+# kadmind (or the Kerberos LDAP behind it) can never delay -- let alone block --
+# the login. The work runs in a forked child; the parent waits at most
+# krbConnectTimeout seconds, then SIGKILLs the child's whole process group.
+#
+# Why fork rather than a plain alarm(): the preferred Authen::Krb5::Admin
+# backend is an XS call into libkadm5; Perl safe-signals cannot interrupt a
+# blocking C syscall, so alarm() alone would not unblock a hung RPC. SIGKILL on
+# a separate process does. Any failure (timeout, fork error, backend error) is
+# thrown and caught by provision(), which always returns PE_OK.
 sub _setKerberosPassword {
+    my ( $self, $princ, $pwd ) = @_;
+
+    my $timeout = $self->conf->{krbConnectTimeout} || 5;
+    require POSIX;
+
+    # Pipe to carry the child's detailed error message back to the parent, so
+    # all logging stays in one place.
+    pipe( my $rdr, my $wtr ) or die "pipe failed: $!\n";
+
+    my $pid = fork();
+    die "fork failed: $!\n" unless defined $pid;
+
+    unless ($pid) {
+
+        # CHILD: isolate in its own session/process group so the parent can
+        # reap any kadmin grandchild too. POSIX::_exit avoids running END/DESTROY
+        # blocks, which would otherwise disturb the portal's shared resources.
+        close $rdr;
+        POSIX::setsid();
+        my $rc = 0;
+        eval {
+            $self->_dispatchBackend( $princ, $pwd );
+            1;
+        } or do {
+            my $e = $@ || 'unknown error';
+            chomp $e;
+            print {$wtr} $e;
+            $rc = 1;
+        };
+        close $wtr;
+        POSIX::_exit($rc);
+    }
+
+    # PARENT: bound the wait. alarm() interrupts waitpid() (a Perl-level wait),
+    # which is enough here because the blocking work lives in the child.
+    close $wtr;
+    my $childErr = '';
+    my $timedOut = 0;
+    {
+        local $SIG{ALRM} = sub { die "alarm\n" };
+        eval {
+            alarm $timeout;
+            waitpid( $pid, 0 );
+            local $/;
+            $childErr = <$rdr> // '';    # small message, EOF is immediate
+            alarm 0;
+            1;
+        } or do { $timedOut = 1 };
+        alarm 0;
+    }
+    close $rdr;
+
+    if ($timedOut) {
+        kill 'KILL', $pid;     # the child itself...
+        kill 'KILL', -$pid;    # ...and any kadmin grandchild in its group
+        waitpid( $pid, 0 );
+        die "kadmind did not respond within ${timeout}s\n";
+    }
+
+    if ( $? != 0 ) {
+        die( ( length $childErr ) ? "$childErr\n" : "kadmin failed\n" );
+    }
+    return 1;
+}
+
+sub _dispatchBackend {
     my ( $self, $princ, $pwd ) = @_;
 
     if ( $self->_krb5AdminAvailable ) {
@@ -275,7 +351,7 @@ sub _runKadmin {
     require Symbol;
 
     my @cmd = ( $self->_kadminBaseArgv, '-q', $query );
-    my $timeout = $self->conf->{krbConnectTimeout} || 3;
+    my $timeout = $self->conf->{krbConnectTimeout} || 5;
 
     my ( $wtr, $rdr, $err );
     $err = Symbol::gensym();

--- a/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
+++ b/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
@@ -6,10 +6,15 @@
 # (kinit / Kerberos SSO) for users whose identities live in a separate, general
 # LDAP directory that the KDC cannot delegate to at kinit time.
 #
-# It hooks `endAuth` (after a successful authentication, when $req->data->{password}
-# is still populated). It is strictly NON-BLOCKING: any provisioning error is
-# logged but never fails the SSO authentication. When there is no cleartext
-# password (SSO cookie reuse, SAML/OIDC/SPNEGO federation) it is a silent no-op.
+# It hooks `betweenAuthAndData`, which runs right after `authenticate` succeeds
+# and BEFORE the second-factor gate (`secondFactor`) and `endAuth`. This is the
+# only stage where success is already guaranteed AND $req->data->{password} is
+# still populated: under MFA, the OTP is submitted in a *second* request that
+# carries no password and only re-runs `buildCookie`+`endAuth`, so hooking
+# `endAuth` would never provision MFA users. It is strictly NON-BLOCKING: any
+# provisioning error is logged but never fails the SSO authentication. When
+# there is no cleartext password (SSO cookie reuse, SAML/OIDC/SPNEGO
+# federation) it is a silent no-op.
 #
 # Two kadmind backends, by order of preference:
 #   1. Authen::Krb5::Admin (libkadm5 bindings) -> in-memory, no shell, no leak.
@@ -30,10 +35,12 @@ extends 'Lemonldap::NG::Portal::Main::Plugin';
 
 use constant name => 'KrbProvisioning';
 
-# Hook: executed at the end of a successful authentication, after the cookie
-# is built. At this stage $req->data->{password} still holds the cleartext
-# password for password-based authentication modules.
-use constant endAuth => 'provision';
+# Hook: executed just after authentication succeeds and before the second
+# factor / session finalization. At this stage $req->data->{password} still
+# holds the cleartext password for password-based authentication modules, and
+# the login is available as $req->{user}. See the file header for why this is
+# preferred over endAuth (MFA compatibility).
+use constant betweenAuthAndData => 'provision';
 
 # Whether the Authen::Krb5::Admin bindings are available. Resolved lazily and
 # only once: if present we use the in-memory API, otherwise we shell to kadmin.
@@ -86,10 +93,13 @@ sub init {
 sub provision {
     my ( $self, $req ) = @_;
 
-    # Resolve the login used to derive the principal.
+    # Resolve the login used to derive the principal. At this stage (before
+    # setSessionInfo) $req->{user} holds the validated login; sessionInfo holds
+    # only what the UserDB populated during getUser. If krbPrincipalAttribute
+    # is set but not yet available, fall back to the login.
     my $attr = $self->conf->{krbPrincipalAttribute};
     my $login =
-        ( defined $attr && length $attr )
+      ( defined $attr && length $attr && defined $req->{sessionInfo}->{$attr} )
       ? $req->{sessionInfo}->{$attr}
       : $req->{user};
 

--- a/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
+++ b/plugins/krb-provisioning/lib/Lemonldap/NG/Portal/Plugins/KrbProvisioning.pm
@@ -88,7 +88,7 @@ sub init {
     return 1;
 }
 
-# RUNNING METHOD (endAuth hook)
+# RUNNING METHOD (betweenAuthAndData hook)
 
 sub provision {
     my ( $self, $req ) = @_;
@@ -144,10 +144,14 @@ sub _principalFor {
     my ( $self, $login ) = @_;
     return undef unless defined $login && length $login;
 
-    # Reject whitespace, NUL, and the principal separators '@' and '/'. Such a
-    # login can't map to a single principal component and is almost certainly a
-    # spoofed / malformed identity.
-    return undef if $login =~ m{[\s\@/\x00]};
+    # Strict allowlist rather than a blocklist: a login becomes a Kerberos
+    # principal component and, in the kadmin fallback, is interpolated into a
+    # quoted `-q` query string. Only accept characters that are unambiguous
+    # there -- letters, digits, dot, underscore, hyphen, plus a trailing '$'
+    # for machine accounts. This rejects whitespace, '@', '/', NUL, quotes,
+    # backslashes and any control/metacharacter that could break or inject the
+    # query.
+    return undef unless $login =~ /\A[A-Za-z0-9._-]+\$?\z/;
 
     my $fmt = $self->conf->{krbPrincipalFormat} || '%s@%s';
     return sprintf( $fmt, $login, $self->conf->{krbRealm} );
@@ -250,11 +254,20 @@ sub _setViaKrb5Admin {
 
     Authen::Krb5::init_context();
 
+    # Target the configured kadmind explicitly rather than relying on the
+    # system krb5.conf / DNS. krbAdminServer is "host[:port]".
+    my ( $host, $port ) = split /:/, $self->conf->{krbAdminServer}, 2;
+    my $config = Authen::Krb5::Admin::Config->new;
+    $config->realm( $self->conf->{krbRealm} );
+    $config->admin_server($host) if defined $host && length $host;
+    $config->kadmind_port( int $port ) if defined $port && length $port;
+
     # Authenticate to kadmind with the service principal via the keytab.
     my $handle = Authen::Krb5::Admin->init_with_skey(
         $self->conf->{krbServicePrincipal},
         $self->conf->{krbKeytab},
         Authen::Krb5::Admin::KADM5_ADMIN_SERVICE(),
+        $config,
     ) or die "kadm5 init failed: " . Authen::Krb5::Admin::error() . "\n";
 
     my $kprinc = Authen::Krb5::parse_name($princ)

--- a/plugins/krb-provisioning/manager-overrides/krb-provisioning.json
+++ b/plugins/krb-provisioning/manager-overrides/krb-provisioning.json
@@ -1,0 +1,115 @@
+{
+  "attributes": {
+    "krbProvisioningActivation": {
+      "type": "bool",
+      "default": 0,
+      "documentation": "Enable on-the-fly Kerberos principal provisioning"
+    },
+    "krbRealm": {
+      "type": "text",
+      "default": "",
+      "documentation": "Kerberos realm of the provisioned principals"
+    },
+    "krbAdminServer": {
+      "type": "text",
+      "default": "",
+      "documentation": "kadmind server as host[:port]"
+    },
+    "krbServicePrincipal": {
+      "type": "text",
+      "default": "",
+      "documentation": "Service principal used to authenticate to kadmind (e.g. lemonldap/admin@REALM)"
+    },
+    "krbKeytab": {
+      "type": "text",
+      "default": "",
+      "documentation": "Path to the keytab of the service principal, readable only by the portal process"
+    },
+    "krbPrincipalAttribute": {
+      "type": "text",
+      "default": "",
+      "documentation": "Session attribute holding the principal name. Empty means the login (REMOTE_USER)."
+    },
+    "krbPrincipalFormat": {
+      "type": "text",
+      "default": "%s@%s",
+      "documentation": "sprintf template applied to (login, realm) to build the principal"
+    },
+    "krbDefaultPolicy": {
+      "type": "text",
+      "default": "",
+      "documentation": "Kerberos policy applied to created principals (optional)"
+    },
+    "krbConnectTimeout": {
+      "type": "int",
+      "default": 3,
+      "documentation": "kadmind connection/command timeout in seconds"
+    }
+  },
+  "tree": [
+    {
+      "insert_into": "generalParameters/plugins",
+      "insert_after": "pamAccess",
+      "nodes": [
+        {
+          "title": "krbProvisioning",
+          "help": "krbprovisioning.html",
+          "form": "simpleInputContainer",
+          "nodes": [
+            "krbProvisioningActivation",
+            "krbRealm",
+            "krbAdminServer",
+            "krbServicePrincipal",
+            "krbKeytab",
+            "krbPrincipalAttribute",
+            "krbPrincipalFormat",
+            "krbDefaultPolicy",
+            "krbConnectTimeout"
+          ]
+        }
+      ]
+    }
+  ],
+  "lang": {
+    "krbProvisioning": {
+      "en": "Kerberos provisioning",
+      "fr": "Provisioning Kerberos"
+    },
+    "krbProvisioningActivation": {
+      "en": "Activation",
+      "fr": "Activation"
+    },
+    "krbRealm": {
+      "en": "Realm",
+      "fr": "Royaume (realm)"
+    },
+    "krbAdminServer": {
+      "en": "Admin server (kadmind)",
+      "fr": "Serveur d'administration (kadmind)"
+    },
+    "krbServicePrincipal": {
+      "en": "Service principal",
+      "fr": "Principal de service"
+    },
+    "krbKeytab": {
+      "en": "Keytab path",
+      "fr": "Chemin du keytab"
+    },
+    "krbPrincipalAttribute": {
+      "en": "Principal session attribute",
+      "fr": "Attribut de session du principal"
+    },
+    "krbPrincipalFormat": {
+      "en": "Principal format",
+      "fr": "Gabarit du principal"
+    },
+    "krbDefaultPolicy": {
+      "en": "Default policy",
+      "fr": "Politique par défaut"
+    },
+    "krbConnectTimeout": {
+      "en": "Connection timeout (s)",
+      "fr": "Délai de connexion (s)"
+    }
+  }
+}

--- a/plugins/krb-provisioning/manager-overrides/krb-provisioning.json
+++ b/plugins/krb-provisioning/manager-overrides/krb-provisioning.json
@@ -42,8 +42,8 @@
     },
     "krbConnectTimeout": {
       "type": "int",
-      "default": 3,
-      "documentation": "kadmind connection/command timeout in seconds"
+      "default": 5,
+      "documentation": "Hard time budget (seconds) for the whole kadmind operation. A non-responding kadmind/LDAP is killed after this delay and never blocks the login."
     }
   },
   "tree": [

--- a/plugins/krb-provisioning/plugin.json
+++ b/plugins/krb-provisioning/plugin.json
@@ -2,7 +2,7 @@
   "name": "krb-provisioning",
   "version": "0.1.0",
   "summary": "On-the-fly Kerberos principal provisioning from SSO logins",
-  "description": "At each real (password-based) login, this LemonLDAP::NG plugin (re)sets the user's Kerberos key equal to the password just validated by the SSO, by talking to a kadmind service. It lets a dedicated MIT KDC issue tickets for users whose identities live in a separate general LDAP directory the KDC cannot delegate to. Hooks endAuth, is strictly non-blocking, never logs or stores the password, and is a silent no-op on cookie SSO or federated logins. Uses Authen::Krb5::Admin when available, otherwise shells to kadmin feeding the password on stdin.",
+  "description": "At each real (password-based) login, this LemonLDAP::NG plugin (re)sets the user's Kerberos key equal to the password just validated by the SSO, by talking to a kadmind service. It lets a dedicated MIT KDC issue tickets for users whose identities live in a separate general LDAP directory the KDC cannot delegate to. Hooks betweenAuthAndData (so it works with MFA), is strictly non-blocking with a hard timeout, never logs or stores the password, and is a silent no-op on cookie SSO or federated logins. Uses Authen::Krb5::Admin when available, otherwise shells to kadmin feeding the password on stdin.",
   "author": "Xavier Guimard <yadd@debian.org>",
   "license": "AGPL-3.0",
   "llng_compat": ">=2.23.0",

--- a/plugins/krb-provisioning/plugin.json
+++ b/plugins/krb-provisioning/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "krb-provisioning",
+  "version": "0.1.0",
+  "summary": "On-the-fly Kerberos principal provisioning from SSO logins",
+  "description": "At each real (password-based) login, this LemonLDAP::NG plugin (re)sets the user's Kerberos key equal to the password just validated by the SSO, by talking to a kadmind service. It lets a dedicated MIT KDC issue tickets for users whose identities live in a separate general LDAP directory the KDC cannot delegate to. Hooks endAuth, is strictly non-blocking, never logs or stores the password, and is a silent no-op on cookie SSO or federated logins. Uses Authen::Krb5::Admin when available, otherwise shells to kadmin feeding the password on stdin.",
+  "author": "Xavier Guimard <yadd@debian.org>",
+  "license": "GPL-2.0",
+  "llng_compat": ">=2.23.0",
+  "customPlugins": "::Plugins::KrbProvisioning",
+  "tags": [
+    "kerberos",
+    "kdc",
+    "provisioning",
+    "kadmin"
+  ],
+  "homepage": "https://github.com/linagora/lemonldap-ng-plugins",
+  "autoload": [
+    {
+      "condition": "krbProvisioningActivation",
+      "module": "::Plugins::KrbProvisioning"
+    }
+  ]
+}

--- a/plugins/krb-provisioning/plugin.json
+++ b/plugins/krb-provisioning/plugin.json
@@ -12,6 +12,7 @@
   "build_depends": [
     "libauthen-krb5-admin-perl"
   ],
+  "ci_container": "debian:trixie",
   "customPlugins": "::Plugins::KrbProvisioning",
   "tags": [
     "kerberos",

--- a/plugins/krb-provisioning/plugin.json
+++ b/plugins/krb-provisioning/plugin.json
@@ -4,7 +4,7 @@
   "summary": "On-the-fly Kerberos principal provisioning from SSO logins",
   "description": "At each real (password-based) login, this LemonLDAP::NG plugin (re)sets the user's Kerberos key equal to the password just validated by the SSO, by talking to a kadmind service. It lets a dedicated MIT KDC issue tickets for users whose identities live in a separate general LDAP directory the KDC cannot delegate to. Hooks endAuth, is strictly non-blocking, never logs or stores the password, and is a silent no-op on cookie SSO or federated logins. Uses Authen::Krb5::Admin when available, otherwise shells to kadmin feeding the password on stdin.",
   "author": "Xavier Guimard <yadd@debian.org>",
-  "license": "GPL-2.0",
+  "license": "AGPL-3.0",
   "llng_compat": ">=2.23.0",
   "customPlugins": "::Plugins::KrbProvisioning",
   "tags": [

--- a/plugins/krb-provisioning/plugin.json
+++ b/plugins/krb-provisioning/plugin.json
@@ -2,10 +2,16 @@
   "name": "krb-provisioning",
   "version": "0.1.0",
   "summary": "On-the-fly Kerberos principal provisioning from SSO logins",
-  "description": "At each real (password-based) login, this LemonLDAP::NG plugin (re)sets the user's Kerberos key equal to the password just validated by the SSO, by talking to a kadmind service. It lets a dedicated MIT KDC issue tickets for users whose identities live in a separate general LDAP directory the KDC cannot delegate to. Hooks betweenAuthAndData (so it works with MFA), is strictly non-blocking with a hard timeout, never logs or stores the password, and is a silent no-op on cookie SSO or federated logins. Uses Authen::Krb5::Admin when available, otherwise shells to kadmin feeding the password on stdin.",
+  "description": "At each real (password-based) login, this LemonLDAP::NG plugin (re)sets the user's Kerberos key equal to the password just validated by the SSO, by talking to a kadmind service via Authen::Krb5::Admin (libkadm5). It lets a dedicated MIT KDC issue tickets for users whose identities live in a separate general LDAP directory the KDC cannot delegate to. Hooks betweenAuthAndData (so it works with MFA), is strictly non-blocking with a hard timeout, never logs or stores the password, and is a silent no-op on cookie SSO or federated logins.",
   "author": "Xavier Guimard <yadd@debian.org>",
   "license": "AGPL-3.0",
   "llng_compat": ">=2.23.0",
+  "perl_requires": {
+    "Authen::Krb5::Admin": "0.17"
+  },
+  "build_depends": [
+    "libauthen-krb5-admin-perl"
+  ],
   "customPlugins": "::Plugins::KrbProvisioning",
   "tags": [
     "kerberos",

--- a/plugins/krb-provisioning/t/01-KrbProvisioning.t
+++ b/plugins/krb-provisioning/t/01-KrbProvisioning.t
@@ -3,6 +3,14 @@ use Test::More;
 use strict;
 use IO::String;
 
+# The plugin hard-requires Authen::Krb5::Admin (Debian: libauthen-krb5-admin-perl);
+# init() refuses to load without it, so there is nothing to test then.
+BEGIN {
+    plan skip_all =>
+      'Authen::Krb5::Admin required (Debian: libauthen-krb5-admin-perl)'
+      unless eval { require Authen::Krb5::Admin; 1 };
+}
+
 require 't/test-lib.pm';
 
 use Lemonldap::NG::Portal::Main::Constants qw(PE_OK);
@@ -183,17 +191,6 @@ count(2);
         'password never appears in any log line' );
     count(3);
 }
-
-# ===========================================================================
-# 6. _kadminBaseArgv: the password is NEVER on the command line
-# ===========================================================================
-my @argv = $plugin->_kadminBaseArgv;
-ok( ( grep { $_ eq '-k' } @argv ), 'kadmin invoked with -k (keytab auth)' );
-ok( ( grep { $_ eq 'lemonldap/admin@EXAMPLE.COM' } @argv ),
-    'service principal present in argv' );
-ok( !( grep { /s3cret|dwho|-pw/ } @argv ),
-    'no password and no -pw flag in argv' );
-count(3);
 
 clean_sessions();
 done_testing();

--- a/plugins/krb-provisioning/t/01-KrbProvisioning.t
+++ b/plugins/krb-provisioning/t/01-KrbProvisioning.t
@@ -1,0 +1,195 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+
+require 't/test-lib.pm';
+
+use Lemonldap::NG::Portal::Main::Constants qw(PE_OK);
+
+my $plugin_class = 'Lemonldap::NG::Portal::Plugins::KrbProvisioning';
+
+# Capture provisioning calls and emitted logs. The actual overrides are
+# installed *after* the portal is initialized (see below): loading the plugin
+# .pm recompiles its subs, so an override placed before init() would be
+# clobbered.
+our @CALLS;
+our @LOGS;
+our $FAIL = 0;
+
+my ( $op, $res );
+
+# The keytab is never read here (the kadmin backend is mocked); any path does.
+ok(
+    $op = LLNG::Manager::Test->new( {
+            ini => {
+                logLevel                => 'error',
+                logger                  => 't::TestStdLogger',
+                domain                  => 'op.com',
+                portal                  => 'http://auth.op.com',
+                authentication          => 'Demo',
+                userDB                  => 'Same',
+                customPlugins           => '::Plugins::KrbProvisioning',
+                krbProvisioningActivation => 1,
+                krbRealm                => 'EXAMPLE.COM',
+                krbAdminServer          => 'kdc.example.com',
+                krbServicePrincipal     => 'lemonldap/admin@EXAMPLE.COM',
+                krbKeytab               => '/nonexistent/krb.keytab',
+            }
+        }
+    ),
+    'Portal with KrbProvisioning initialized'
+);
+
+my $plugin = $op->p->loadedModules->{$plugin_class};
+ok( $plugin, 'KrbProvisioning plugin is loaded' );
+count(1);
+
+# ---------------------------------------------------------------------------
+# Install overrides now that the plugin and the test logger are loaded.
+# Method dispatch is resolved at call time, so these affect every subsequent
+# login handled by the in-process portal. A flag lets us simulate a kadmind
+# failure to prove the hook stays non-blocking.
+# ---------------------------------------------------------------------------
+{
+    no warnings 'redefine';
+    *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_setKerberosPassword =
+      sub {
+        my ( $self, $princ, $pwd ) = @_;
+        push @CALLS, { princ => $princ, pwd => $pwd };
+        die "simulated kadmind failure\n" if $FAIL;
+        return 1;
+      };
+
+    # Capture every emitted log line so we can assert the password never leaks.
+    *t::TestStdLogger::logprint = sub {
+        my ( $level, $message ) = @_;
+        push @LOGS, "[$level] $message";
+    };
+}
+
+# ===========================================================================
+# 1. Real login (password present) -> principal is provisioned end-to-end
+# ===========================================================================
+@CALLS = ();
+my $id = $op->login('dwho');
+ok( $id, 'Login succeeded and returned a session cookie' );
+is( scalar @CALLS, 1, 'Exactly one provisioning call on real login' );
+is( $CALLS[0]->{princ}, 'dwho@EXAMPLE.COM', 'Principal mapped to <uid>@REALM' );
+is( $CALLS[0]->{pwd},   'dwho',             'Cleartext password passed to backend' );
+count(4);
+
+# ===========================================================================
+# 2. Cookie SSO (no re-auth) -> no kadmin call (silent no-op)
+# ===========================================================================
+@CALLS = ();
+ok(
+    $res = $op->_get(
+        '/',
+        cookie => "lemonldap=$id",
+        accept => 'text/html',
+    ),
+    'GET / with an existing session cookie'
+);
+is( scalar @CALLS, 0, 'No provisioning on cookie SSO (no cleartext password)' );
+count(2);
+
+# ===========================================================================
+# 3. kadmind failure -> authentication still succeeds (non-blocking)
+# ===========================================================================
+{
+    @CALLS = ();
+    @LOGS  = ();
+    local $FAIL = 1;
+    my $id2 = $op->login('rtyler');
+    ok( $id2, 'Login still succeeds even though kadmind provisioning failed' );
+    is( scalar @CALLS, 1, 'Provisioning was attempted' );
+    ok( ( grep { /KrbProvisioning: failed to provision/ } @LOGS ),
+        'Provisioning failure was logged at error level' );
+    count(3);
+}
+
+# ===========================================================================
+# 4. _principalFor: mapping and rejection of invalid logins
+# ===========================================================================
+is( $plugin->_principalFor('alice'),
+    'alice@EXAMPLE.COM', '_principalFor builds <uid>@REALM' );
+is( $plugin->_principalFor(''),       undef, 'empty login rejected' );
+is( $plugin->_principalFor('a b'),    undef, 'login with space rejected' );
+is( $plugin->_principalFor('a@b'),    undef, 'login with @ rejected' );
+is( $plugin->_principalFor('a/b'),    undef, 'login with / rejected' );
+count(5);
+
+# ===========================================================================
+# 5. provision(): no-op guards via a lightweight fake request
+# ===========================================================================
+{
+    no warnings 'redefine', 'once';
+    *FakeReq::data = sub { $_[0]->{_data} };
+}
+
+# No cleartext password -> PE_OK, no call (federation / cookie path)
+@CALLS = ();
+my $req_nopwd = bless { user => 'dwho', sessionInfo => {}, _data => {} },
+  'FakeReq';
+is( $plugin->provision($req_nopwd), PE_OK, 'provision returns PE_OK with no password' );
+is( scalar @CALLS, 0, 'no backend call when password is absent' );
+count(2);
+
+# Password present, valid login -> one call
+@CALLS = ();
+my $req_ok = bless {
+    user        => 'dwho',
+    sessionInfo => {},
+    _data       => { password => 's3cret' },
+  },
+  'FakeReq';
+is( $plugin->provision($req_ok), PE_OK, 'provision returns PE_OK on success' );
+is( scalar @CALLS, 1, 'one backend call when password present' );
+is( $CALLS[0]->{princ}, 'dwho@EXAMPLE.COM', 'correct principal from fake req' );
+count(3);
+
+# Invalid login -> PE_OK, no call
+@CALLS = ();
+my $req_bad = bless {
+    user        => 'evil user',
+    sessionInfo => {},
+    _data       => { password => 's3cret' },
+  },
+  'FakeReq';
+is( $plugin->provision($req_bad), PE_OK, 'provision returns PE_OK on invalid login' );
+is( scalar @CALLS, 0, 'no backend call for an invalid login' );
+count(2);
+
+# A distinctive password (which cannot appear in the principal) must never be
+# logged, even when provisioning fails and an error line is emitted.
+{
+    local $FAIL = 1;
+    @LOGS = ();
+    my $req_secret = bless {
+        user        => 'alice',
+        sessionInfo => {},
+        _data       => { password => 'T0pS3cr3tValue' },
+      },
+      'FakeReq';
+    is( $plugin->provision($req_secret), PE_OK, 'provision PE_OK despite failure' );
+    ok( ( grep { /failed to provision principal alice\@EXAMPLE\.COM/ } @LOGS ),
+        'error logged with the principal name' );
+    ok( !( grep { /T0pS3cr3tValue/ } @LOGS ),
+        'password never appears in any log line' );
+    count(3);
+}
+
+# ===========================================================================
+# 6. _kadminBaseArgv: the password is NEVER on the command line
+# ===========================================================================
+my @argv = $plugin->_kadminBaseArgv;
+ok( ( grep { $_ eq '-k' } @argv ), 'kadmin invoked with -k (keytab auth)' );
+ok( ( grep { $_ eq 'lemonldap/admin@EXAMPLE.COM' } @argv ),
+    'service principal present in argv' );
+ok( !( grep { /s3cret|dwho|-pw/ } @argv ),
+    'no password and no -pw flag in argv' );
+count(3);
+
+clean_sessions();
+done_testing();

--- a/plugins/krb-provisioning/t/01-KrbProvisioning.t
+++ b/plugins/krb-provisioning/t/01-KrbProvisioning.t
@@ -52,7 +52,7 @@ count(1);
 # failure to prove the hook stays non-blocking.
 # ---------------------------------------------------------------------------
 {
-    no warnings 'redefine';
+    no warnings 'redefine', 'once';
     *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_setKerberosPassword =
       sub {
         my ( $self, $princ, $pwd ) = @_;

--- a/plugins/krb-provisioning/t/01-KrbProvisioning.t
+++ b/plugins/krb-provisioning/t/01-KrbProvisioning.t
@@ -118,7 +118,11 @@ is( $plugin->_principalFor(''),       undef, 'empty login rejected' );
 is( $plugin->_principalFor('a b'),    undef, 'login with space rejected' );
 is( $plugin->_principalFor('a@b'),    undef, 'login with @ rejected' );
 is( $plugin->_principalFor('a/b'),    undef, 'login with / rejected' );
-count(5);
+is( $plugin->_principalFor('a"b'),    undef, 'login with double-quote rejected (query injection)' );
+is( $plugin->_principalFor('a\\b'),   undef, 'login with backslash rejected' );
+is( $plugin->_principalFor("a\tb"),   undef, 'login with control char rejected' );
+is( $plugin->_principalFor('host$'),  'host$@EXAMPLE.COM', 'machine account ($) accepted' );
+count(8);
 
 # ===========================================================================
 # 5. provision(): no-op guards via a lightweight fake request

--- a/plugins/krb-provisioning/t/02-KrbProvisioning-MFA.t
+++ b/plugins/krb-provisioning/t/02-KrbProvisioning-MFA.t
@@ -1,0 +1,112 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+
+require 't/test-lib.pm';
+
+# This test proves the plugin provisions Kerberos correctly when a second
+# factor (MFA) is enabled. The password is only present on the FIRST request
+# (credentials), which ends at the 2FA gate; the OTP is submitted in a SECOND
+# request that carries no password and only re-runs buildCookie + endAuth.
+# Hooking betweenAuthAndData (not endAuth) is what makes this work.
+#
+# Uses LLNG's bundled external-2F helper scripts (t/sendOTP.pl, t/vrfyOTP.pl),
+# which accept user "dwho" and code "123456".
+
+my $plugin_class = 'Lemonldap::NG::Portal::Plugins::KrbProvisioning';
+our @CALLS;
+
+my ( $op, $res );
+
+ok(
+    $op = LLNG::Manager::Test->new( {
+            ini => {
+                logLevel                => 'error',
+                domain                  => 'op.com',
+                portal                  => 'http://auth.op.com',
+                authentication          => 'Demo',
+                userDB                  => 'Same',
+                ext2fActivation         => 1,
+                ext2fCodeActivation     => 0,
+                ext2FSendCommand        => 't/sendOTP.pl -uid $uid',
+                ext2FValidateCommand    => 't/vrfyOTP.pl -uid $uid -code $code',
+                customPlugins           => '::Plugins::KrbProvisioning',
+                krbProvisioningActivation => 1,
+                krbRealm                => 'EXAMPLE.COM',
+                krbAdminServer          => 'kdc.example.com',
+                krbServicePrincipal     => 'lemonldap/admin@EXAMPLE.COM',
+                krbKeytab               => '/nonexistent/krb.keytab',
+            }
+        }
+    ),
+    'Portal with KrbProvisioning + external 2F'
+);
+
+# Capture provisioning calls instead of talking to a real kadmind (installed
+# after init, see 01-KrbProvisioning.t for the rationale).
+{
+    no warnings 'redefine';
+    *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_setKerberosPassword =
+      sub {
+        my ( $self, $princ, $pwd ) = @_;
+        push @CALLS, { princ => $princ, pwd => $pwd };
+        return 1;
+      };
+}
+
+# ===========================================================================
+# Step 1: submit credentials -> second factor required (no cookie yet)
+# ===========================================================================
+@CALLS = ();
+my $body = 'user=dwho&password=dwho';
+ok(
+    $res = $op->_post(
+        '/',
+        IO::String->new($body),
+        length => length($body),
+        accept => 'text/html',
+    ),
+    'Step 1: credentials submitted'
+);
+count(1);
+
+# The response is the external-2F form: authentication is pending the second
+# factor (the user is NOT logged in yet). Extracting it proves that.
+my ( $host, $url, $query ) =
+  expectForm( $res, undef, '/ext2fcheck?skin=bootstrap', 'token', 'code' );
+ok( !getCookies($res)->{lemonldap},
+    'No full session cookie yet (2FA pending)' );
+
+# ...but the Kerberos principal was already provisioned, with the password,
+# during betweenAuthAndData -- before the 2FA gate.
+is( scalar @CALLS, 1, 'Provisioned on the credentials request (before 2FA)' );
+is( $CALLS[0]->{princ}, 'dwho@EXAMPLE.COM', 'Correct principal' );
+is( $CALLS[0]->{pwd},   'dwho', 'Cleartext password captured before 2FA' );
+count(4);
+
+# Fill the OTP and submit.
+$query =~ s/code=/code=123456/;
+
+# ===========================================================================
+# Step 2: submit the OTP -> authentication completes (cookie issued)
+# ===========================================================================
+ok(
+    $res = $op->_post(
+        '/ext2fcheck',
+        IO::String->new($query),
+        length => length($query),
+        accept => 'text/html',
+    ),
+    'Step 2: OTP submitted'
+);
+my $id = expectCookie($res);
+ok( $id, 'Got a session cookie after 2FA' );
+
+# The OTP request has no password: endAuth must NOT trigger a second (no-op)
+# provisioning. Total stays at exactly one.
+is( scalar @CALLS, 1, 'No extra provisioning on the OTP request (no password)' );
+count(2);
+
+clean_sessions();
+done_testing();

--- a/plugins/krb-provisioning/t/02-KrbProvisioning-MFA.t
+++ b/plugins/krb-provisioning/t/02-KrbProvisioning-MFA.t
@@ -3,6 +3,12 @@ use Test::More;
 use strict;
 use IO::String;
 
+BEGIN {
+    plan skip_all =>
+      'Authen::Krb5::Admin required (Debian: libauthen-krb5-admin-perl)'
+      unless eval { require Authen::Krb5::Admin; 1 };
+}
+
 require 't/test-lib.pm';
 
 # This test proves the plugin provisions Kerberos correctly when a second

--- a/plugins/krb-provisioning/t/02-KrbProvisioning-MFA.t
+++ b/plugins/krb-provisioning/t/02-KrbProvisioning-MFA.t
@@ -46,7 +46,7 @@ ok(
 # Capture provisioning calls instead of talking to a real kadmind (installed
 # after init, see 01-KrbProvisioning.t for the rationale).
 {
-    no warnings 'redefine';
+    no warnings 'redefine', 'once';
     *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_setKerberosPassword =
       sub {
         my ( $self, $princ, $pwd ) = @_;

--- a/plugins/krb-provisioning/t/03-KrbProvisioning-Timeout.t
+++ b/plugins/krb-provisioning/t/03-KrbProvisioning-Timeout.t
@@ -1,0 +1,86 @@
+use warnings;
+use Test::More;
+use strict;
+
+require 't/test-lib.pm';
+
+use Lemonldap::NG::Portal::Main::Constants qw(PE_OK);
+
+# Proves the hard timeout: a kadmind/LDAP that never answers must not delay --
+# let alone block -- the login. The real _setKerberosPassword (fork + bounded
+# waitpid + SIGKILL) is exercised here; only the backend dispatch is stubbed to
+# hang, so the parent must give up after krbConnectTimeout and still return
+# PE_OK.
+
+my $plugin_class = 'Lemonldap::NG::Portal::Plugins::KrbProvisioning';
+our @LOGS;
+
+my $op;
+ok(
+    $op = LLNG::Manager::Test->new( {
+            ini => {
+                logLevel                => 'error',
+                logger                  => 't::TestStdLogger',
+                domain                  => 'op.com',
+                portal                  => 'http://auth.op.com',
+                authentication          => 'Demo',
+                userDB                  => 'Same',
+                customPlugins           => '::Plugins::KrbProvisioning',
+                krbProvisioningActivation => 1,
+                krbRealm                => 'EXAMPLE.COM',
+                krbAdminServer          => 'kdc.example.com',
+                krbServicePrincipal     => 'lemonldap/admin@EXAMPLE.COM',
+                krbKeytab               => '/nonexistent/krb.keytab',
+                krbConnectTimeout       => 1,
+            }
+        }
+    ),
+    'Portal initialized with a 1s kadmind timeout'
+);
+
+my $plugin = $op->p->loadedModules->{$plugin_class};
+ok( $plugin, 'KrbProvisioning plugin is loaded' );
+count(1);
+
+# Stub the backend so it hangs far longer than the timeout. The forked child
+# runs this (and is SIGKILLed); the real _setKerberosPassword wrapper stays.
+{
+    no warnings 'redefine', 'once';
+    *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_dispatchBackend =
+      sub { sleep 30; return 1; };
+
+    # Capture logs to confirm the timeout is reported (without the password).
+    *t::TestStdLogger::logprint = sub {
+        my ( $level, $message ) = @_;
+        push @LOGS, "[$level] $message";
+    };
+}
+
+# FakeReq mirrors what provision() reads from a real request.
+{
+    no warnings 'redefine', 'once';
+    *FakeReq::data = sub { $_[0]->{_data} };
+}
+my $req = bless {
+    user        => 'dwho',
+    sessionInfo => {},
+    _data       => { password => 'T0pS3cr3tValue' },
+  },
+  'FakeReq';
+
+@LOGS = ();
+my $t0      = time;
+my $rc      = $plugin->provision($req);
+my $elapsed = time - $t0;
+
+is( $rc, PE_OK, 'provision returns PE_OK when kadmind never answers' );
+cmp_ok( $elapsed, '<', 6,
+    "login not blocked: provision returned in ${elapsed}s (timeout 1s)" );
+ok( ( grep { /did not respond within/ } @LOGS ),
+    'timeout reported in the logs' );
+ok( !( grep { /T0pS3cr3tValue/ } @LOGS ),
+    'password never appears in the timeout log' );
+count(4);
+
+clean_sessions();
+done_testing();

--- a/plugins/krb-provisioning/t/03-KrbProvisioning-Timeout.t
+++ b/plugins/krb-provisioning/t/03-KrbProvisioning-Timeout.t
@@ -2,6 +2,12 @@ use warnings;
 use Test::More;
 use strict;
 
+BEGIN {
+    plan skip_all =>
+      'Authen::Krb5::Admin required (Debian: libauthen-krb5-admin-perl)'
+      unless eval { require Authen::Krb5::Admin; 1 };
+}
+
 require 't/test-lib.pm';
 
 use Lemonldap::NG::Portal::Main::Constants qw(PE_OK);
@@ -46,7 +52,7 @@ count(1);
 # runs this (and is SIGKILLed); the real _setKerberosPassword wrapper stays.
 {
     no warnings 'redefine', 'once';
-    *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_dispatchBackend =
+    *Lemonldap::NG::Portal::Plugins::KrbProvisioning::_setViaKrb5Admin =
       sub { sleep 30; return 1; };
 
     # Capture logs to confirm the timeout is reported (without the password).


### PR DESCRIPTION
## Summary

New LemonLDAP::NG plugin **`krb-provisioning`** that provisions/resyncs a
user's Kerberos principal on the KDC **at each real login**, using the
cleartext password the SSO already holds while validating the user against
the general directory.

Implements the spec from the `pure-kdc` project
(`docs/llng-kerberos-provisioning-plugin.md`).

### Why

A dedicated MIT KDC keeps its principals in a separate OpenLDAP base and
cannot delegate authentication to the general identity directory at `kinit`
time — it needs the key derived from the password. The SSO login is the only
moment that password is seen in clear, so that is where the key is built.

### Behavior

- **`endAuth` hook** — runs after a successful auth, while
  `$req->data->{password}` is still populated.
- **Idempotent** — `addprinc` on first login, `cpw` on every subsequent login
  (absorbs password drift in the general directory).
- **Strictly non-blocking** — kadmind errors are logged and swallowed; SSO
  always succeeds (always returns `PE_OK`).
- **Silent no-op** without a cleartext password (cookie SSO, SAML/OIDC,
  SPNEGO).
- **Password safety** — never logged, never passed in argv (no `-pw`).
  Prefers `Authen::Krb5::Admin` (in-memory `libkadm5`), falls back to
  `kadmin` fed on **stdin**, with a short timeout.

### Out of scope

Deprovisioning, realm/`krbContainer`/service-account creation — handled by
`pure-kdc` and a separate reconciliation job.

## Configuration

`krbProvisioningActivation`, `krbRealm`, `krbAdminServer`,
`krbServicePrincipal`, `krbKeytab`, `krbPrincipalAttribute`,
`krbPrincipalFormat`, `krbDefaultPolicy`, `krbConnectTimeout`.
See the plugin README for the full table.

## Tests

`./mcp/cli.js test krb-provisioning` → **39/39 passing**. The kadmind backend
is mocked (no real KDC needed); tests cover principal mapping, the no-op
paths, the non-blocking guarantee, and the password-never-logged /
never-in-argv constraints.

## Notes

- Marked **alpha** in the root README plugin table.
- No version bump of existing plugins; CHANGELOG left for release time.