### PR TITLE
feat(pam-access): probe mode for /pam/bastion-token (fix ob-bastion-id 403)

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1163,6 +1163,26 @@ sub bastionToken {
     my $target_host  = $body->{target_host}  || '';
     my $target_group = $body->{target_group} || 'default';
 
+    # Probe mode (ob-bastion-id): a server self-identifying the bastion_id it
+    # would receive does not vouch for any real user, so the per-user _pamSeen
+    # recency gate below does not apply, and no `user` is required. Steps 1-4
+    # already proved the caller holds a valid device-grant token for a group
+    # listed in pamAccessBastionGroups — which is exactly what authorises it
+    # to learn its own bastion_id. We return the identifier only, never a
+    # usable JWT, so probe mode cannot be abused to mint credentials.
+    if ( $body->{probe} ) {
+        $self->logger->info( "PAM bastion-token: probe request — "
+              . "returning bastion_id '$bastion_id' (group=$server_group)" );
+        return $self->p->sendJSONresponse(
+            $req,
+            {
+                bastion_id   => $bastion_id,
+                server_group => $server_group,
+                probe        => JSON::true(),
+            }
+        );
+    }
+
     unless ($user) {
         return $self->_badRequest( $req, 'Missing user parameter' );
     }


### PR DESCRIPTION
`ob-bastion-id` (in [linagora/open-bastion](https://github.com/linagora/open-bastion)) self-identifies by POSTing to `/pam/bastion-token`. The endpoint now gates on a per-user `_pamSeen` recency marker, which `ob-bastion-id`'s synthetic probe user can never have — so every `ob-bastion-id` run returns **HTTP 403** ("User has never authenticated on this portal via pam-access").

## Change
Add a **probe mode** to `bastionToken`: when the JSON body contains `"probe": true`, return the `bastion_id` directly and stop, before the `user`/`_pamSeen` checks:

```json
{ "bastion_id": "...", "server_group": "...", "probe": true }
```

- No usable JWT is minted in probe mode, so it cannot be abused to obtain credentials for an arbitrary user.
- The earlier validations are unchanged and still apply: valid Device-Authorization-Grant bearer token, correct scope, and the server's group must be listed in `pamAccessBastionGroups`. So only a legitimate bastion can learn its own id.

## Companion PR
Client side: linagora/open-bastion#119 (`ob-bastion-id` sends `"probe": true` and reads `bastion_id` from the response, with a fallback to JWT decoding for portals without this change).

## Validation
`perl -c` OK against the local LLNG `blib/lib`.