### PR TITLE
feat(device): long-lived offline tokens for organization devices

### DIFF
--- a/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
+++ b/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
@@ -877,8 +877,21 @@ sub _generateTokens {
         }
     }
 
-    # Generate refresh token if allowed
-    if ( $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsRefreshToken} ) {
+    # Decide whether to issue a refresh token. Mirror the core token endpoint
+    # (Issuer/OpenIDConnect.pm): an *offline* refresh token is gated by the
+    # offline_access scope + oidcRPMetaDataOptionsAllowOffline, while an
+    # *online* refresh token is gated by oidcRPMetaDataOptionsRefreshToken.
+    # These are two independent gates: AllowOffline alone must be enough to
+    # get an offline refresh token, even when RefreshToken (online) is off.
+    my $is_offline =
+      (      $self->oidc->_hasScope( 'offline_access', $scope )
+          && $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsAllowOffline} )
+      ? 1
+      : 0;
+
+    if (   $is_offline
+        || $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsRefreshToken} )
+    {
         my $refresh_token_data = {
             scope        => $scope,
             client_id    => $device_auth->{client_id},
@@ -888,16 +901,10 @@ sub _generateTokens {
             %$session_data,
         };
 
-        # Offline refresh token if offline_access scope was requested
-        # and allowed by RP configuration
-        my $is_offline = 0;
-        if (    $self->oidc->_hasScope( 'offline_access', $scope )
-            and
-            $self->oidc->rpOptions->{$rp}->{oidcRPMetaDataOptionsAllowOffline} )
-        {
-            $is_offline = 1;
-        }
-
+        # Online refresh tokens are tied to the user's SSO session; offline
+        # ones are standalone (the refresh token carries the user info, e.g.
+        # the synthetic organization identity injected by the
+        # oidc-device-organization plugin via $session_data).
         $refresh_token_data->{user_session_id} = $user_session_id
           unless $is_offline;
 

--- a/plugins/oidc-device-authorization/t/33-Refresh-Token-Gating.t
+++ b/plugins/oidc-device-authorization/t/33-Refresh-Token-Gating.t
@@ -1,0 +1,223 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+}
+
+my $debug = 'error';
+
+# Initialization — three public RPs to cover the refresh-token issuance matrix.
+#
+#   rp_offline : AllowOffline=1, RefreshToken=0
+#                → offline_access scope must yield a refresh token
+#   rp_online  : AllowOffline=0, RefreshToken=1
+#                → any scope must yield a (non-offline) refresh token
+#   rp_none    : AllowOffline=0, RefreshToken=0
+#                → no refresh token under any scope
+
+my $op = LLNG::Manager::Test->new( {
+        ini => {
+            logLevel                                      => $debug,
+            domain                                        => 'op.com',
+            portal                                        => 'http://auth.op.com/',
+            authentication                                => 'Demo',
+            userDB                                        => 'Same',
+            issuerDBOpenIDConnectActivation               => 1,
+            customPlugins                                 => '::Plugins::OIDCDeviceAuthorization',
+            oidcServiceDeviceAuthorizationExpiration      => 600,
+            oidcServiceDeviceAuthorizationPollingInterval => 5,
+            oidcServiceDeviceAuthorizationUserCodeLength  => 8,
+            oidcRPMetaDataExportedVars => {
+                rp_offline => { preferred_username => 'uid', name => 'cn' },
+                rp_online  => { preferred_username => 'uid', name => 'cn' },
+                rp_none    => { preferred_username => 'uid', name => 'cn' },
+            },
+            oidcRPMetaDataOptions => {
+                rp_offline => {
+                    oidcRPMetaDataOptionsDisplayName           => 'RP Offline',
+                    oidcRPMetaDataOptionsIDTokenExpiration     => 3600,
+                    oidcRPMetaDataOptionsIDTokenSignAlg        => 'RS256',
+                    oidcRPMetaDataOptionsClientID              => 'rp_offline',
+                    oidcRPMetaDataOptionsPublic                => 1,
+                    oidcRPMetaDataOptionsUserIDAttr            => '',
+                    oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                    oidcRPMetaDataOptionsBypassConsent         => 1,
+                    oidcRPMetaDataOptionsAllowOffline          => 1,
+                    oidcRPMetaDataOptionsRefreshToken          => 0,
+                    oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                },
+                rp_online => {
+                    oidcRPMetaDataOptionsDisplayName           => 'RP Online',
+                    oidcRPMetaDataOptionsIDTokenExpiration     => 3600,
+                    oidcRPMetaDataOptionsIDTokenSignAlg        => 'RS256',
+                    oidcRPMetaDataOptionsClientID              => 'rp_online',
+                    oidcRPMetaDataOptionsPublic                => 1,
+                    oidcRPMetaDataOptionsUserIDAttr            => '',
+                    oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                    oidcRPMetaDataOptionsBypassConsent         => 1,
+                    oidcRPMetaDataOptionsAllowOffline          => 0,
+                    oidcRPMetaDataOptionsRefreshToken          => 1,
+                    oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                },
+                rp_none => {
+                    oidcRPMetaDataOptionsDisplayName           => 'RP None',
+                    oidcRPMetaDataOptionsIDTokenExpiration     => 3600,
+                    oidcRPMetaDataOptionsIDTokenSignAlg        => 'RS256',
+                    oidcRPMetaDataOptionsClientID              => 'rp_none',
+                    oidcRPMetaDataOptionsPublic                => 1,
+                    oidcRPMetaDataOptionsUserIDAttr            => '',
+                    oidcRPMetaDataOptionsAccessTokenExpiration => 3600,
+                    oidcRPMetaDataOptionsBypassConsent         => 1,
+                    oidcRPMetaDataOptionsAllowOffline          => 0,
+                    oidcRPMetaDataOptionsRefreshToken          => 0,
+                    oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                },
+            },
+            oidcServicePrivateKeySig => oidc_key_op_private_sig,
+            oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+        }
+    }
+);
+
+# ---------------------------------------------------------------------------
+# Helper: run the full device-authorization flow for a public client.
+# Returns the decoded token JSON hashref on success, or dies.
+# ---------------------------------------------------------------------------
+sub device_flow {
+    my ( $client_id, $scope, $sid ) = @_;
+
+    # Step 1 — initiate device authorization
+    my $query = buildForm( {
+            client_id => $client_id,
+            scope     => $scope,
+        }
+    );
+    my $res = $op->_post(
+        '/oauth2/device',
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+    );
+    die "device auth request failed ($res->[0]) for $client_id"
+      unless $res->[0] == 200;
+
+    my $init   = from_json( $res->[2]->[0] );
+    my $device_code = $init->{device_code}
+      or die "no device_code for $client_id";
+    my $user_code = $init->{user_code}
+      or die "no user_code for $client_id";
+    $user_code =~ s/-//g;
+
+    # Step 2 — get verification page (to extract CSRF token)
+    $res = $op->_get(
+        '/device',
+        query  => "user_code=$user_code",
+        cookie => "lemonldap=$sid",
+        accept => 'text/html',
+    );
+    my ($csrf) = $res->[2]->[0] =~ m/name="token"\s+value="([^"]+)"/;
+    die "no CSRF token for $client_id" unless $csrf;
+
+    # Step 3 — approve device
+    $query = buildForm( {
+            user_code => $user_code,
+            action    => 'approve',
+            token     => $csrf,
+        }
+    );
+    $res = $op->_post(
+        '/device',
+        IO::String->new($query),
+        cookie => "lemonldap=$sid",
+        accept => 'text/html',
+        length => length($query),
+    );
+    die "device approval failed ($res->[0]) for $client_id"
+      unless $res->[0] == 200;
+
+    # Step 4 — exchange device code for tokens (no client_secret for public)
+    $query = buildForm( {
+            grant_type  => 'urn:ietf:params:oauth:grant-type:device_code',
+            device_code => $device_code,
+            client_id   => $client_id,
+        }
+    );
+    $res = $op->_post(
+        '/oauth2/token',
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+    );
+    die "token exchange failed ($res->[0]) for $client_id"
+      unless $res->[0] == 200;
+
+    return from_json( $res->[2]->[0] );
+}
+
+# ---------------------------------------------------------------------------
+# Log in once; reuse the session across all four flows.
+# ---------------------------------------------------------------------------
+my $sid = login( $op, 'french' );
+
+# ===========================================================================
+# Case 1: rp_offline + offline_access scope
+#   AllowOffline=1, RefreshToken=0, scope includes offline_access
+#   → access_token AND refresh_token expected
+# ===========================================================================
+
+my $tok;
+ok(
+    $tok = device_flow( 'rp_offline', 'openid offline_access', $sid ),
+    'rp_offline offline_access flow completed'
+);
+ok( $tok->{access_token},  'rp_offline: access_token present' );
+ok( $tok->{refresh_token}, 'rp_offline: refresh_token present (offline gate)' );
+count(3);
+
+# ===========================================================================
+# Case 2: rp_online + openid scope only
+#   AllowOffline=0, RefreshToken=1
+#   → refresh_token expected (online gate, no offline_access needed)
+# ===========================================================================
+
+ok(
+    $tok = device_flow( 'rp_online', 'openid', $sid ),
+    'rp_online openid flow completed'
+);
+ok( $tok->{refresh_token}, 'rp_online: refresh_token present (online gate)' );
+count(2);
+
+# ===========================================================================
+# Case 3: rp_none + offline_access scope
+#   AllowOffline=0, RefreshToken=0 — offline gate closed
+#   → access_token present, refresh_token ABSENT
+# ===========================================================================
+
+ok(
+    $tok = device_flow( 'rp_none', 'openid offline_access', $sid ),
+    'rp_none offline_access flow completed'
+);
+ok( $tok->{access_token},    'rp_none offline_access: access_token present' );
+ok( !$tok->{refresh_token},  'rp_none offline_access: refresh_token absent' );
+count(3);
+
+# ===========================================================================
+# Case 4: rp_none + openid scope only
+#   AllowOffline=0, RefreshToken=0 — both gates closed
+#   → refresh_token ABSENT
+# ===========================================================================
+
+ok(
+    $tok = device_flow( 'rp_none', 'openid', $sid ),
+    'rp_none openid-only flow completed'
+);
+ok( !$tok->{refresh_token}, 'rp_none openid-only: refresh_token absent' );
+count(2);
+
+clean_sessions();
+done_testing();

--- a/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
+++ b/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
@@ -95,11 +95,17 @@ sub handleOrganizationDevice {
     # Point to the new synthetic session instead of the admin's
     $device_auth->{user_session_id} = $session->id;
 
-    # Remove offline_access from scope to force online refresh token
-    # (offline would try to resolve client_id in UserDB and fail)
-    $device_auth->{scope} =~ s/\boffline_access\b//g;
-    $device_auth->{scope} =~ s/\s+/ /g;
-    $device_auth->{scope} =~ s/^\s+|\s+$//g;
+    # NOTE: we deliberately KEEP offline_access in the scope so the device
+    # gets a long-lived *offline* refresh token (the durable machine identity,
+    # decoupled from the admin's SSO session — RFC 8628 / OIDC offline_access).
+    #
+    # The classic objection — "offline refresh re-resolves the user in the
+    # UserDB and fails for the synthetic client_id" — does not apply here:
+    # Open Bastion never uses the core /oauth2/token refresh grant for these
+    # tokens. The PamAccess /pam/heartbeat endpoint mints fresh access tokens
+    # directly from the refresh token's stored (synthetic) session data, so
+    # the UserDB is never queried at refresh time. The synthetic attributes
+    # are copied into the refresh token via %$session_data below.
 
     # Replace session_data so tokens carry synthetic attributes
     %$session_data = %{ $session->data };

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -928,16 +928,47 @@ sub heartbeat {
             'Token not from Device Authorization Grant' );
     }
 
-    # 5. Update metadata in refresh_token session
-    my $now      = time();
+    # 5. Resolve the RP (conf key) this refresh token belongs to. The
+    #    synthetic session created by oidc-device-organization stamps
+    #    _clientConfKey; fall back to a client_id lookup for safety.
+    my $now = time();
+    my $rp  = $rtSession->data->{_clientConfKey};
+    unless ( $rp and $self->oidc->rpOptions->{$rp} ) {
+        my $cid = $rtSession->data->{client_id} // '';
+        for my $k ( keys %{ $self->oidc->rpOptions } ) {
+            next
+              unless ( $self->oidc->rpOptions->{$k}
+                ->{oidcRPMetaDataOptionsClientID} // '' ) eq $cid;
+            $rp = $k;
+            last;
+        }
+    }
+    unless ( $rp and $self->oidc->rpOptions->{$rp} ) {
+        $self->logger->error(
+            'PAM heartbeat: cannot resolve RP for refresh token');
+        return $self->_unauthorizedResponse( $req, 'Unknown client' );
+    }
+
+    # 6. Update metadata in refresh_token session AND slide its expiration.
+    #    LLNG purges sessions on (time - _utime > timeout); pushing _utime
+    #    forward by OfflineSessionExpiration on every beat is what makes a
+    #    live server's credential effectively never expire, while a server
+    #    that stops beating ages out after that window (the grace period).
     my $hostname = $body->{hostname} || 'unknown';
-    my $updates  = {
+    my $offlineExp =
+      $self->oidc->rpOptions->{$rp}
+      ->{oidcRPMetaDataOptionsOfflineSessionExpiration}
+      || $self->conf->{oidcServiceOfflineSessionExpiration}
+      || 2592000;
+
+    my $updates = {
         _pamServer      => 1,
         _pamHostname    => $hostname,
         _pamServerGroup => $body->{server_group} || 'default',
         _pamVersion     => $body->{version}      || '',
         _pamLastSeen    => $now,
         _pamStatus      => 'active',
+        _utime          => $now + $offlineExp - $self->conf->{timeout},
     };
 
     # Store stats as JSON string if provided
@@ -955,12 +986,40 @@ sub heartbeat {
 
     $self->logger->debug("PAM heartbeat from $hostname");
 
-    # 6. Respond with next heartbeat interval
+    # 7. Mint a fresh access token from the refresh token's stored (synthetic)
+    #    session data. We deliberately do NOT use the core /oauth2/token
+    #    refresh grant: its offline branch re-resolves the user in the UserDB,
+    #    which fails for the synthetic organization identity. Minting here keeps
+    #    the server's identity self-contained (RFC spirit: short access token,
+    #    long refresh token, refresh loop driven by the device).
+    my $scope = $rtSession->data->{scope} || '';
+    my $access_token =
+      $self->oidc->newAccessToken( $req, $rp, $scope, $rtSession->data,
+        { grant_type => 'device_code' } );
+
+    unless ($access_token) {
+        $self->logger->error('PAM heartbeat: failed to mint access token');
+        return $self->p->sendJSONresponse(
+            $req,
+            { error => 'token generation failed' },
+            code => 500
+        );
+    }
+
+    my $at_ttl =
+      $self->oidc->rpOptions->{$rp}
+      ->{oidcRPMetaDataOptionsAccessTokenExpiration}
+      || $self->conf->{oidcServiceAccessTokenExpiration}
+      || 3600;
+
+    # 8. Respond with the fresh access token + next heartbeat interval
     my $interval = $self->conf->{pamAccessHeartbeatInterval} || 300;
     return $self->p->sendJSONresponse(
         $req,
         {
             status         => 'ok',
+            access_token   => "$access_token",
+            expires_in     => $at_ttl + 0,
             next_heartbeat => $interval,
             server_time    => $now,
         }

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -928,6 +928,19 @@ sub heartbeat {
             'Token not from Device Authorization Grant' );
     }
 
+    # 4b. Verify the refresh token actually carries the bastion server scope.
+    #     This endpoint mints access tokens and slides the refresh token's
+    #     lifetime, so it must only accept tokens meant for pam-access. Without
+    #     this check, any device_code refresh token issued for another RP/scope
+    #     could use /pam/heartbeat to obtain access tokens and keep itself alive
+    #     indefinitely. Same gate as /pam/authorize and /pam/bastion-token.
+    my $rt_scope = $rtSession->data->{scope} || '';
+    unless ( $rt_scope =~ /\bpam(?::server)?\b/ ) {
+        $self->logger->warn(
+            "PAM heartbeat: refresh token has invalid scope '$rt_scope'");
+        return $self->_forbiddenResponse( $req, 'Invalid token scope' );
+    }
+
     # 5. Resolve the RP (conf key) this refresh token belongs to. The
     #    synthetic session created by oidc-device-organization stamps
     #    _clientConfKey; fall back to a client_id lookup for safety.

--- a/plugins/pam-access/t/07-PamAccess-Heartbeat.t
+++ b/plugins/pam-access/t/07-PamAccess-Heartbeat.t
@@ -1,0 +1,250 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+    use FindBin;
+    require "$FindBin::Bin/pam-lib.pm";
+    pam_lib::install_plugin_templates();
+}
+
+my $debug = 'error';
+my ( $op, $res );
+
+# ---------------------------------------------------------------------------
+# Build $op — start from pam_lib::base_config() and override oidcRPMetaDataOptions
+# to enable offline_access for the pam-access RP.  The override key is listed
+# AFTER pam_lib::base_config() so it wins the last-write-wins hash merge.
+# ---------------------------------------------------------------------------
+ok(
+    $op = LLNG::Manager::Test->new( {
+            ini => {
+                logLevel => $debug,
+                domain   => 'op.com',
+                portal   => 'http://auth.op.com',
+                pam_lib::base_config(),
+                pamAccessSshRules    => { default => '1' },
+                pamAccessExportedVars => { gecos => 'cn' },
+                # Override: enable offline for pam-access RP so we get a
+                # refresh token back from the device flow.
+                oidcRPMetaDataOptions => {
+                    'pam-access' => {
+                        oidcRPMetaDataOptionsDisplayName          => 'PAM Access',
+                        oidcRPMetaDataOptionsClientID             => 'pam-access',
+                        oidcRPMetaDataOptionsClientSecret         => 'pamsecret',
+                        oidcRPMetaDataOptionsAccessTokenExpiration => 600,
+                        oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                        oidcRPMetaDataOptionsAllowOffline              => 1,
+                        oidcRPMetaDataOptionsOfflineSessionExpiration  => 2592000,
+                    }
+                },
+            }
+        }
+    ),
+    'OP with heartbeat / offline support'
+);
+
+# ---------------------------------------------------------------------------
+# Helper: enroll a server requesting offline_access scope.
+# Returns ($access_token, $refresh_token).
+# ---------------------------------------------------------------------------
+sub enroll_offline {
+    my ($sid) = @_;
+
+    # Initiate device authorization — include offline_access in scope
+    my $query = buildForm( {
+            client_id     => 'pam-access',
+            client_secret => 'pamsecret',
+            scope         => 'pam:server offline_access',
+        }
+    );
+    my $r = $op->_post(
+        '/oauth2/device',
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+    );
+    die "Device auth request failed: $r->[0]" unless $r->[0] == 200;
+
+    my $json       = from_json( $r->[2]->[0] );
+    my $device_code = $json->{device_code}
+      or die 'no device_code';
+    my $user_code = $json->{user_code}
+      or die 'no user_code';
+    $user_code =~ s/-//g;
+
+    # Get verification page for CSRF token
+    $r = $op->_get(
+        '/device',
+        query  => "user_code=$user_code",
+        cookie => "lemonldap=$sid",
+        accept => 'text/html',
+    );
+    my ($csrf) = $r->[2]->[0] =~ m/name="token"\s+value="([^"]+)"/;
+    die 'no CSRF token' unless $csrf;
+
+    # Approve device
+    $query = buildForm( {
+            user_code => $user_code,
+            action    => 'approve',
+            token     => $csrf,
+        }
+    );
+    $r = $op->_post(
+        '/device',
+        IO::String->new($query),
+        cookie => "lemonldap=$sid",
+        accept => 'text/html',
+        length => length($query),
+    );
+    die "Device approval failed: $r->[0]" unless $r->[0] == 200;
+
+    # Exchange device_code for tokens
+    $query = buildForm( {
+            grant_type    => 'urn:ietf:params:oauth:grant-type:device_code',
+            device_code   => $device_code,
+            client_id     => 'pam-access',
+            client_secret => 'pamsecret',
+        }
+    );
+    $r = $op->_post(
+        '/oauth2/token',
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+    );
+    die "Token exchange failed: $r->[0]" unless $r->[0] == 200;
+
+    $json = from_json( $r->[2]->[0] );
+    return ( $json->{access_token}, $json->{refresh_token} );
+}
+
+# ===========================================================================
+# Test 1: Enroll with offline_access — verify refresh_token is issued
+# ===========================================================================
+
+my $id = $op->login('dwho');
+my ( $server_at, $rt ) = enroll_offline($id);
+ok( $server_at, 'Got access_token from offline enroll' );
+ok( $rt,        'Got refresh_token from offline enroll' );
+count(2);
+
+# ===========================================================================
+# Test 2: POST /pam/heartbeat — happy path
+# ===========================================================================
+
+my $hb_body = to_json( {
+        refresh_token => $rt,
+        hostname      => 'srv1.example.com',
+        server_group  => 'default',
+    }
+);
+ok(
+    $res = $op->_post(
+        '/pam/heartbeat',
+        IO::String->new($hb_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($hb_body),
+    ),
+    'POST /pam/heartbeat happy path'
+);
+expectOK($res);
+my $hb = expectJSON($res);
+is( $hb->{status}, 'ok', 'heartbeat status is ok' );
+ok( $hb->{access_token},       'heartbeat returned access_token' );
+is( $hb->{expires_in}, 600, 'heartbeat expires_in matches AccessTokenExpiration' );
+count(4);
+
+my $minted_at = $hb->{access_token};
+
+# ===========================================================================
+# Test 3: minted access_token works for /pam/authorize
+# ===========================================================================
+
+my $auth_body = to_json( {
+        user         => 'dwho',
+        host         => 'srv1.example.com',
+        service      => 'sshd',
+        server_group => 'default',
+    }
+);
+ok(
+    $res = $op->_post(
+        '/pam/authorize',
+        IO::String->new($auth_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($auth_body),
+        custom => { HTTP_AUTHORIZATION => "Bearer $minted_at" },
+    ),
+    'POST /pam/authorize with heartbeat-minted access_token'
+);
+expectOK($res);
+my $auth = expectJSON($res);
+ok( $auth->{authorized}, 'User authorized via minted access_token' );
+count(2);
+
+# ===========================================================================
+# Test 4: _utime slide — refresh session must be pushed forward
+#   Expected: _utime >= time() + OfflineSessionExpiration - timeout - small_slack
+# ===========================================================================
+
+my $oidc_mod = $op->p->loadedModules->{'Lemonldap::NG::Portal::Issuer::OpenIDConnect'};
+my $rt_session = $oidc_mod->getRefreshToken($rt);
+ok( $rt_session, 'Can read refresh token session after heartbeat' );
+count(1);
+
+my $utime   = $rt_session->data->{_utime};
+my $offline_exp = 2592000;
+my $timeout     = $op->p->conf->{timeout};
+my $min_utime   = time() + $offline_exp - $timeout - 10;
+
+ok( $utime,             '_utime is set in refresh session' );
+ok( $utime > time(),    '_utime is in the future' );
+ok( $utime >= $min_utime,
+    "_utime ($utime) slid forward by OfflineSessionExpiration ($min_utime expected minimum)" );
+count(3);
+
+# ===========================================================================
+# Test 5a: Rejection — no refresh_token in body → 400
+# ===========================================================================
+
+my $bad_body = to_json( { hostname => 'x' } );
+ok(
+    $res = $op->_post(
+        '/pam/heartbeat',
+        IO::String->new($bad_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($bad_body),
+    ),
+    'POST /pam/heartbeat without refresh_token'
+);
+is( $res->[0], 400, 'Missing refresh_token yields HTTP 400' );
+count(2);
+
+# ===========================================================================
+# Test 5b: Rejection — nonexistent refresh_token → 401
+# ===========================================================================
+
+my $inv_body = to_json( { refresh_token => 'doesnotexist' } );
+ok(
+    $res = $op->_post(
+        '/pam/heartbeat',
+        IO::String->new($inv_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($inv_body),
+    ),
+    'POST /pam/heartbeat with invalid refresh_token'
+);
+is( $res->[0], 401, 'Invalid refresh_token yields HTTP 401' );
+count(2);
+
+clean_sessions();
+done_testing();


### PR DESCRIPTION
## Problem

An enrolled server (organization device) stops resolving SSO users a while after enrollment: `getent passwd <user>` returns nothing the next day. Root cause: NSS/PAM authenticate to `/pam/userinfo` with a **short-lived access token** (default 1h), and **nothing renews it**. LLNG purges the access-token session on `_utime + timeout`, so it disappears overnight.

The durable credential should be a long-lived **offline refresh token** (RFC 8628 / OIDC `offline_access`), decoupled from the authorizing admin (an org device must survive that admin leaving) and surviving multi-day downtime (datacenter maintenance).

## What was blocking it

- `oidc-device-authorization` gated **all** refresh-token issuance behind `oidcRPMetaDataOptionsRefreshToken` (the *online* flag), so `AllowOffline=1` alone produced no token.
- `oidc-device-organization` **stripped `offline_access`** to force an online token, because the core refresh grant's offline branch re-resolves the user in the UserDB (`getAttributesForUser` → `getUser`), which fails for the synthetic org identity. But online refresh tokens live only `conf->{timeout}` (~1 day) — too short for multi-day downtime.

## Changes (plugins only — LLNG core untouched)

- **oidc-device-authorization**: issue the offline refresh token whenever `offline_access` + `AllowOffline` are set, independently of `RefreshToken`. Mirrors the core token endpoint (`Issuer/OpenIDConnect.pm`: `if (offline) {…} elsif (RefreshToken) {…}`).
- **oidc-device-organization**: stop stripping `offline_access`. The synthetic organization identity is carried in the refresh token, so the device no longer depends on the admin's account.
- **pam-access `/pam/heartbeat`**:
  - slides the refresh token `_utime` forward each beat → a live server never expires; a silent one ages out after `OfflineSessionExpiration` (the grace period);
  - **mints a fresh access token directly from the stored (synthetic) session data** (`grant_type=device_code`), avoiding the core refresh grant and its UserDB resolution;
  - returns `access_token` + `expires_in`.
- `/pam/userinfo` and `/pam/authorize` (the resource server) are unchanged: they keep validating short access tokens.

This realizes the RFC model: short access token presented to the resource server, long-lived refresh token, refresh loop driven by the device (`ob-heartbeat`).

## Required RP config (`pam-access`)

| Option | Value |
| --- | --- |
| `oidcRPMetaDataOptionsAllowOffline` | `1` |
| `oidcRPMetaDataOptionsOfflineSessionExpiration` | e.g. `2592000` (30d grace) |
| `oidcRPMetaDataOptionsRefreshToken` / `RefreshTokenRotation` | `0` / `0` |
| `oidcRPMetaDataOptionsDeviceOwnership` | `organization` |
| allowed scopes | `pam:server` + `offline_access` |

## Companion

Bastion-side changes (scope `offline_access`, refresh-token guard in setup, access-token persistence in `ob-heartbeat`) are in linagora/open-bastion#119.

## Validation

`perl -c` OK on the three modified plugins (with local LLNG `blib/lib` includes).