### PR TITLE
feat(pam-access): certificate-based bastion→backend vouching

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1737,6 +1737,21 @@ sub _checkSshFingerprint {
 }
 
 # Is $server_group one of the configured bastion groups?
+# Read a positive-integer duration from conf, falling back to $default when
+# the key is unset or misconfigured. A non-numeric or <= 0 value would mint
+# immediately-expired vouchers or break the ssh-keygen -V validity spec.
+sub _confPositiveInt {
+    my ( $self, $key, $default ) = @_;
+    my $v = $self->conf->{$key};
+    return $default unless defined $v && $v ne '';
+    unless ( $v =~ /\A[0-9]+\z/ && $v > 0 ) {
+        $self->logger->warn(
+            "PamAccess: ignoring invalid $key value '$v', using $default");
+        return $default;
+    }
+    return $v + 0;
+}
+
 sub _isBastionGroup {
     my ( $self, $server_group ) = @_;
     return 0 unless defined $server_group && $server_group ne '';
@@ -1761,7 +1776,8 @@ sub _mintBastionVoucher {
     }
 
     my $now    = time();
-    my $ttlCap = $self->conf->{pamAccessBastionVoucherTtl} || 43200;    # 12h
+    my $ttlCap =
+      $self->_confPositiveInt( 'pamAccessBastionVoucherTtl', 43200 );    # 12h
     my $exp    = $now + $ttlCap;
     $exp = $cert_expires_at
       if $cert_expires_at && $cert_expires_at > $now && $cert_expires_at < $exp;
@@ -1917,11 +1933,20 @@ sub bastionCert {
         );
 
         # Machine-readable reason so ob-ssh-proxy can show a precise message
-        # (e.g. 'voucher_expired' -> "reconnect to the bastion").
+        # (e.g. 'voucher_expired' -> "reconnect to the bastion"). Internal
+        # conditions (session backend failure, corrupted voucher map) are
+        # server errors, not authorization denials: 5xx keeps clients and
+        # monitoring from treating them as a 403 "reconnect to the bastion".
+        my $internal = $vres->{reason} =~
+          /\A(?:no_session|session_error|voucher_corrupted)\z/;
         return $self->p->sendJSONresponse(
             $req,
-            { error => 'voucher_rejected', reason => $vres->{reason} },
-            code => 403
+            {
+                error => $internal ? 'voucher_check_failed'
+                : 'voucher_rejected',
+                reason => $vres->{reason}
+            },
+            code => $internal ? 500 : 403
         );
     }
 
@@ -1944,7 +1969,7 @@ sub bastionCert {
     my $keyId = sprintf( 'bastion=%s;user=%s;target=%s',
         $clean->($bastion_id), $clean->($user), $clean->($target_host) );
 
-    my $ttl    = $self->conf->{pamAccessBastionCertTtl} || 120;
+    my $ttl    = $self->_confPositiveInt( 'pamAccessBastionCertTtl', 120 );
     my $serial = $sshca->_getNextSerial;
     my %signOpts = ( validity => "+${ttl}s" );
 
@@ -2102,6 +2127,55 @@ Response:
   "reason": "..." (only if denied)
 }
 
+When the calling server belongs to a bastion group (see
+C<pamAccessBastionGroups>), a successful authorization also returns:
+{
+  "bastion_voucher": "uuid",
+  "bastion_voucher_expires_in": 43200
+}
+
+The voucher is a reusable (bastion, user) capability stored in the user's
+persistent session; the bastion later presents it to C</pam/bastion-cert>.
+
+=head2 POST /pam/bastion-cert
+
+Sign a short-lived ephemeral SSH user certificate for a bastion-to-backend
+hop (requires the ssh-ca plugin). The bastion proves it holds a valid
+device-grant Bearer token for a bastion group, plus a fresh
+(bastion, user) voucher minted by C</pam/authorize> when the user actually
+connected to it. The certificate is pinned to the bastion's IP
+(C<source-address> critical option) and encodes the bastion identity in
+its key-id so backends can enforce an allowed-bastions list.
+
+Requires: Bearer token in Authorization header
+
+Request body:
+{
+  "user": "username",
+  "target_host": "backend.example.com",
+  "target_group": "production",
+  "public_key": "ssh-ed25519 AAAA... ephemeral",
+  "voucher": "uuid"
+}
+
+Response:
+{
+  "certificate": "ssh-ed25519-cert-v01@openssh.com AAAA...",
+  "expires_in": 120,
+  "serial": 1234,
+  "key_id": "bastion=...;user=...;target=..."
+}
+
+On voucher rejection, returns 403 with a machine-readable reason
+(C<no_voucher_supplied>, C<voucher_expired>, C<voucher_mismatch>); internal
+failures (session backend error, corrupted voucher map) return 500.
+
+=head2 POST /pam/bastion-token (DEPRECATED)
+
+Legacy JWT-based vouching endpoint, superseded by C</pam/bastion-cert>
+(see F<doc/design/bastion-cert-vouching.md>). Kept for backward
+compatibility only.
+
 =head2 POST /pam/heartbeat
 
 Server heartbeat for monitoring enrolled PAM servers.
@@ -2159,6 +2233,24 @@ received (default: 900)
 
 If enabled, servers must have a recent heartbeat to use /pam/authorize.
 This ensures that the PAM module is still active on the server. (default: 0)
+
+=item pamAccessBastionGroups
+
+Comma/space-separated list of server groups considered bastions
+(default: 'bastion'). Members of these groups get a bastion voucher from
+C</pam/authorize> and may call C</pam/bastion-cert>.
+
+=item pamAccessBastionVoucherTtl
+
+Maximum validity of a bastion voucher in seconds (default: 43200, i.e. 12h).
+The voucher is further capped by the user's SSO certificate expiry when
+known. Must be a positive integer; invalid values fall back to the default.
+
+=item pamAccessBastionCertTtl
+
+Validity of the ephemeral certificates issued by C</pam/bastion-cert>, in
+seconds (default: 120). Must be a positive integer; invalid values fall
+back to the default.
 
 =item pamAccessChoice
 

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -89,8 +89,20 @@ sub init {
 
       # Route for bastion token generation (bastion -> LLNG)
       # Returns a JWT that proves the bastion has a valid session
+      # DEPRECATED: the SendEnv/pam_getenv transport this JWT relied on is
+      # structurally broken (see doc/design/bastion-cert-vouching.md). Kept for
+      # backward-compat; superseded by /pam/bastion-cert below.
       ->addUnauthRoute(
         pam => { 'bastion-token' => 'bastionToken' },
+        ['POST']
+      )
+
+      # Route for bastion ephemeral-certificate vouching (bastion -> LLNG).
+      # The bastion sends an ephemeral public key + the (bastion_id, user)
+      # voucher minted by /pam/authorize; LLNG returns a short-lived,
+      # CA-signed user certificate the bastion uses to connect to the backend.
+      ->addUnauthRoute(
+        pam => { 'bastion-cert' => 'bastionCert' },
         ['POST']
       )
 
@@ -373,9 +385,10 @@ sub authorize {
         },
     );
     return $fp_bail if $fp_bail;
+    my $sshCheck;    # captured for the bastion-voucher cap below
     if ( defined $fingerprint ) {
 
-        my $sshCheck = $self->_checkSshFingerprint( $user, $fingerprint );
+        $sshCheck = $self->_checkSshFingerprint( $user, $fingerprint );
         unless ( $sshCheck->{ok} ) {
             $self->logger->info(
                 "PAM authorize: SSH fingerprint check failed for user '$user' "
@@ -496,6 +509,28 @@ sub authorize {
             $self->logger->debug(
 "PAM authorize: offline mode enabled for user '$user' (TTL: ${offlineTtl}s)"
             );
+        }
+
+        # Bastion vouching: when the caller is itself a bastion, mint a
+        # reusable (bastion_id, user) voucher bound to this real connection.
+        # The bastion later presents it to /pam/bastion-cert to obtain
+        # short-lived certs for THIS user only — closing the hole where a
+        # bastion could vouch for any user it never saw. Bound to the user's
+        # SSO cert lifetime when a fingerprint matched above.
+        if ( $self->_isBastionGroup($server_group) ) {
+            my ( $nonce, $vexp ) = $self->_mintBastionVoucher(
+                $req, $user, $server_id,
+                ( $sshCheck && $sshCheck->{ok} )
+                ? $sshCheck->{expires_at}
+                : undef
+            );
+            if ($nonce) {
+                $response->{bastion_voucher}            = $nonce;
+                $response->{bastion_voucher_expires_in} = $vexp - time();
+                $self->logger->debug(
+"PAM authorize: minted bastion voucher for user '$user' (bastion='$server_id', exp=$vexp)"
+                );
+            }
         }
     }
     else {
@@ -1691,13 +1726,279 @@ sub _checkSshFingerprint {
             return { ok => 0, reason => 'expired' };
         }
         return {
-            ok     => 1,
-            serial => $cert->{serial},
-            label  => $cert->{label},
-            key_id => $cert->{key_id},
+            ok         => 1,
+            serial     => $cert->{serial},
+            label      => $cert->{label},
+            key_id     => $cert->{key_id},
+            expires_at => $cert->{expires_at},
         };
     }
     return { ok => 0, reason => 'not-found' };
+}
+
+# Is $server_group one of the configured bastion groups?
+sub _isBastionGroup {
+    my ( $self, $server_group ) = @_;
+    return 0 unless defined $server_group && $server_group ne '';
+    my $bastion_groups = $self->conf->{pamAccessBastionGroups} || 'bastion';
+    for my $allowed ( split /[,;\s]+/, $bastion_groups ) {
+        return 1 if $server_group eq $allowed;
+    }
+    return 0;
+}
+
+# Mint (replace) a reusable (bastion_id, user) voucher in the user's persistent
+# session. Validity is capped by the user's SSO cert expiry when known, else by
+# pamAccessBastionVoucherTtl (default 12h). Returns ($nonce, $exp) or ().
+sub _mintBastionVoucher {
+    my ( $self, $req, $user, $bastion_id, $cert_expires_at ) = @_;
+
+    my $nonce = $self->_generateUUID();
+    unless ($nonce) {
+        $self->logger->error(
+            'PAM authorize: cannot generate bastion voucher nonce');
+        return ();
+    }
+
+    my $now    = time();
+    my $ttlCap = $self->conf->{pamAccessBastionVoucherTtl} || 43200;    # 12h
+    my $exp    = $now + $ttlCap;
+    $exp = $cert_expires_at
+      if $cert_expires_at && $cert_expires_at > $now && $cert_expires_at < $exp;
+
+    my $ps = $self->p->getPersistentSession($user);
+    unless ( $ps && !$ps->error ) {
+        $self->logger->error(
+            "PAM authorize: cannot load persistent session for '$user' "
+              . "to store bastion voucher" );
+        return ();
+    }
+
+    my $raw  = $ps->data->{_pamBastionVouchers};
+    my $vmap = $raw ? eval { from_json($raw) } : {};
+    $vmap = {} unless ref $vmap eq 'HASH';
+
+    # Prune expired/invalid entries so the map stays bounded.
+    for my $k ( keys %$vmap ) {
+        delete $vmap->{$k}
+          if ref $vmap->{$k} ne 'HASH' || ( $vmap->{$k}{exp} || 0 ) <= $now;
+    }
+    $vmap->{$bastion_id} = { nonce => $nonce, exp => $exp };
+    $ps->update( { _pamBastionVouchers => to_json($vmap) } );
+
+    return ( $nonce, $exp );
+}
+
+# Validate a (bastion_id, user) voucher presented by a bastion at /pam/bastion-cert.
+# $ps is the user's already-loaded persistent session. Returns { ok => 1 } or
+# { ok => 0, reason => '...' } with a machine-readable reason.
+sub _checkBastionVoucher {
+    my ( $self, $ps, $bastion_id, $voucher ) = @_;
+
+    return { ok => 0, reason => 'no_session' } unless $ps;
+    return { ok => 0, reason => 'session_error' } if $ps->error;
+    return { ok => 0, reason => 'no_voucher_supplied' }
+      unless defined $voucher && $voucher ne '';
+
+    my $raw = $ps->data->{_pamBastionVouchers};
+    return { ok => 0, reason => 'voucher_expired' } unless $raw;
+
+    my $vmap = eval { from_json($raw) };
+    return { ok => 0, reason => 'voucher_corrupted' }
+      if $@ || ref $vmap ne 'HASH';
+
+    my $entry = $vmap->{$bastion_id};
+    return { ok => 0, reason => 'voucher_expired' }
+      unless $entry && ref $entry eq 'HASH';
+    return { ok => 0, reason => 'voucher_expired' }
+      if ( $entry->{exp} || 0 ) <= time();
+    return { ok => 0, reason => 'voucher_mismatch' }
+      unless ( $entry->{nonce} || '' ) eq $voucher;
+
+    return { ok => 1 };
+}
+
+# POST /pam/bastion-cert - Sign a short-lived user certificate for a bastion
+#
+# The bastion proves: (1) it holds a valid device-grant token for a bastion
+# group (Bearer); (2) it holds a fresh (bastion_id, user) voucher minted by
+# /pam/authorize when this user actually connected to it. LLNG then signs the
+# supplied ephemeral public key with the ssh-ca CA key, pinning the cert to the
+# bastion's IP (source-address) and encoding bastion_id in the key-id so the
+# backend can enforce its allowed-bastions list.
+#
+# Request: { user, target_host, target_group, public_key, voucher }
+# Response: { certificate, expires_in, serial, key_id }
+sub bastionCert {
+    my ( $self, $req ) = @_;
+
+    # 1-4. Same caller gates as bastionToken: valid device-grant token, pam
+    #      scope, and a resolved server_group that is a bastion group.
+    my $access_token = $self->oidc->getEndPointAccessToken($req);
+    return $self->_unauthorizedResponse( $req, 'Bearer token required' )
+      unless $access_token;
+
+    my $tokenSession = $self->oidc->getAccessToken($access_token);
+    return $self->_unauthorizedResponse( $req, 'Invalid or expired token' )
+      unless $tokenSession;
+
+    my $grant_type = $tokenSession->data->{grant_type} || '';
+    return $self->_forbiddenResponse( $req,
+        'Server not enrolled. Use Device Authorization Grant.' )
+      unless $grant_type eq 'device_code';
+
+    my $scope = $tokenSession->data->{scope} || '';
+    return $self->_forbiddenResponse( $req, 'Invalid token scope' )
+      unless $scope =~ /\bpam(?::server)?\b/;
+
+    my $bastion_id    = $tokenSession->data->{client_id} || 'unknown';
+    my $session_group = $tokenSession->data->{server_group};
+    my $server_group =
+      $self->_resolveServerGroup( $req, $bastion_id, $session_group,
+        'PAM bastion-cert' );
+    return $self->_forbiddenResponse( $req, $server_group->{message} )
+      if ref $server_group eq 'HASH' && $server_group->{rejected};
+
+    unless ( $self->_isBastionGroup($server_group) ) {
+        $self->logger->warn( "PAM bastion-cert: server group '$server_group' "
+              . "is not a bastion group" );
+        return $self->_forbiddenResponse( $req,
+            "Server is not an authorized bastion (group: $server_group)" );
+    }
+
+    # 5. Parse + validate request body.
+    my $body = eval { from_json( $req->content ) };
+    if ($@) {
+        $self->logger->error("PAM bastion-cert: Invalid JSON body: $@");
+        return $self->_badRequest( $req, 'Invalid JSON' );
+    }
+
+    my $user         = $body->{user};
+    my $target_host  = $body->{target_host}  || '';
+    my $target_group = $body->{target_group} || 'default';
+    my $public_key   = $body->{public_key};
+    my $voucher      = $body->{voucher};
+
+    return $self->_badRequest( $req, 'Missing user parameter' ) unless $user;
+
+    # The principal we sign equals the unix login; reject separators that
+    # ssh-keygen -n would split into multiple principals or that would poison
+    # the key-id encoding.
+    return $self->_badRequest( $req, 'Invalid user parameter' )
+      if $user =~ m{[\s,/;]};
+
+    return $self->_badRequest( $req, 'Missing public_key parameter' )
+      unless $public_key;
+    return $self->_badRequest( $req, 'Missing voucher parameter' )
+      unless $voucher;
+
+    # Strict SSH public key validation (same contract as ssh-ca /ssh/sign).
+    unless ( $public_key =~
+        /\A(ssh-\w+|ecdsa-sha2-\w+)\s+[A-Za-z0-9+\/]+={0,2}(?:\s+[^\r\n]*)?\z/ )
+    {
+        return $self->_badRequest( $req, 'Invalid SSH public key format' );
+    }
+
+    # 6. Voucher check: proves this user really connected to THIS bastion.
+    my $ps   = $self->p->getPersistentSession($user);
+    my $vres = $self->_checkBastionVoucher( $ps, $bastion_id, $voucher );
+    unless ( $vres->{ok} ) {
+        $self->logger->info(
+                "PAM bastion-cert: voucher rejected for user '$user' "
+              . "(bastion='$bastion_id', reason=$vres->{reason})" );
+        $self->p->auditLog(
+            $req,
+            code        => 'PAM_BASTION_CERT_VOUCHER_REJECTED',
+            user        => $user,
+            message     => "PAM bastion-cert denied: $vres->{reason}",
+            bastion_id  => $bastion_id,
+            target_host => $target_host,
+            reason      => $vres->{reason},
+        );
+
+        # Machine-readable reason so ob-ssh-proxy can show a precise message
+        # (e.g. 'voucher_expired' -> "reconnect to the bastion").
+        return $self->p->sendJSONresponse(
+            $req,
+            { error => 'voucher_rejected', reason => $vres->{reason} },
+            code => 403
+        );
+    }
+
+    # 7. Reach the ssh-ca plugin to sign with the CA key.
+    my $sshca =
+      $self->p->loadedModules->{'Lemonldap::NG::Portal::Plugins::SSHCA'};
+    unless ( $sshca && $sshca->can('_signSshKey') && $sshca->sshPrivKey ) {
+        $self->logger->error(
+            'PAM bastion-cert: SSHCA plugin not available/initialised');
+        return $self->p->sendJSONresponse(
+            $req,
+            { error => 'SSH CA not available' },
+            code => 500
+        );
+    }
+
+    # 8. Encode bastion identity in the key-id for the backend to allowlist.
+    #    Sanitize each part so the `k=v;` encoding stays unambiguous.
+    my $clean = sub { my $v = shift // ''; $v =~ s/[^A-Za-z0-9._-]/_/g; $v };
+    my $keyId = sprintf( 'bastion=%s;user=%s;target=%s',
+        $clean->($bastion_id), $clean->($user), $clean->($target_host) );
+
+    my $ttl    = $self->conf->{pamAccessBastionCertTtl} || 120;
+    my $serial = $sshca->_getNextSerial;
+    my %signOpts = ( validity => "+${ttl}s" );
+
+    # Pin the cert to the vouching bastion's IP (sshd-native enforcement).
+    my $bastion_ip = $req->address;
+    if ( defined $bastion_ip && $bastion_ip =~ /\A[0-9a-fA-F:.]+\z/ ) {
+        $signOpts{source_address} = $bastion_ip;
+    }
+
+    my $result =
+      $sshca->_signSshKey( $public_key, [$user], 2, $serial, $keyId,
+        \%signOpts );
+    unless ( $result && $result->{certificate} ) {
+        $self->logger->error(
+            "PAM bastion-cert: signing failed for user '$user'");
+        return $self->p->sendJSONresponse(
+            $req,
+            { error => 'Failed to sign certificate' },
+            code => 500
+        );
+    }
+
+    $self->p->auditLog(
+        $req,
+        code    => 'PAM_BASTION_CERT_ISSUED',
+        user    => $user,
+        message =>
+          "Bastion ephemeral cert issued for '$user' to '$target_host'",
+        bastion_id   => $bastion_id,
+        target_host  => $target_host,
+        target_group => $target_group,
+        serial       => $serial,
+        key_id       => $keyId,
+        ttl          => $ttl,
+        (
+            $signOpts{source_address}
+            ? ( source_address => $signOpts{source_address} )
+            : ()
+        ),
+    );
+
+    $self->logger->info( "PAM bastion-cert: issued cert serial=$serial for "
+          . "user '$user' (bastion='$bastion_id' -> '$target_host', ttl=${ttl}s)"
+    );
+
+    return $self->p->sendJSONresponse(
+        $req,
+        {
+            certificate => $result->{certificate},
+            expires_in  => $ttl + 0,
+            serial      => $serial,
+            key_id      => $keyId,
+        }
+    );
 }
 
 1;

--- a/plugins/pam-access/t/08-PamAccess-BastionCert.t
+++ b/plugins/pam-access/t/08-PamAccess-BastionCert.t
@@ -1,0 +1,272 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use JSON;
+use File::Temp qw(tempdir);
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+    use FindBin;
+    require "$FindBin::Bin/pam-lib.pm";
+    pam_lib::install_plugin_templates();
+}
+
+# This endpoint signs real SSH certificates by forking ssh-keygen, and needs
+# openssl to mint the CA key — skip cleanly where they are unavailable.
+system("which ssh-keygen >/dev/null 2>&1") == 0
+  or plan skip_all => "ssh-keygen not available";
+system("which openssl >/dev/null 2>&1") == 0
+  or plan skip_all => "openssl not available";
+
+my $debug = 'error';
+my ( $op, $res );
+
+# --- Generate an SSH CA keypair (PEM) for the ssh-ca plugin -------------------
+my ( $ca_private_key, $ca_public_key );
+{
+    my $tmpdir = tempdir( CLEANUP => 1 );
+    system(
+"openssl genrsa 2048 2>/dev/null | openssl rsa -traditional -out $tmpdir/ca.key 2>/dev/null"
+    ) == 0
+      or plan skip_all => "openssl key generation failed";
+    system(
+        "openssl rsa -in $tmpdir/ca.key -pubout -out $tmpdir/ca.pub 2>/dev/null")
+      == 0
+      or plan skip_all => "openssl pubkey extraction failed";
+    local $/;
+    open my $fh, '<', "$tmpdir/ca.key" or die;
+    $ca_private_key = <$fh>;
+    close $fh;
+    open $fh, '<', "$tmpdir/ca.pub" or die;
+    $ca_public_key = <$fh>;
+    close $fh;
+}
+
+# --- Generate an ephemeral user keypair (what a bastion would mint) -----------
+my $eph_pubkey;
+{
+    my $tmpdir = tempdir( CLEANUP => 1 );
+    system("ssh-keygen -t ed25519 -f $tmpdir/eph -N '' -q -C ephemeral-hop") == 0
+      or plan skip_all => "ssh-keygen key generation failed";
+    open my $fh, '<', "$tmpdir/eph.pub" or die;
+    $eph_pubkey = <$fh>;
+    close $fh;
+    chomp $eph_pubkey;
+}
+
+my $krl = tempdir( CLEANUP => 1 ) . "/revoked_keys";
+
+# --- OP with pam-access + ssh-ca (cert vouching) -----------------------------
+ok(
+    $op = LLNG::Manager::Test->new( {
+            ini => {
+                logLevel => $debug,
+                domain   => 'op.com',
+                portal   => 'http://auth.op.com',
+                pam_lib::base_config(),
+
+                # Add SSHCA on top of base_config's customPlugins.
+                customPlugins =>
+'::Plugins::PamAccess ::Plugins::OIDCDeviceAuthorization ::Plugins::SSHCA',
+
+                # ssh-ca CA key
+                sshCaKeyRef  => 'ssh-ca',
+                sshCaKrlPath => $krl,
+                keys         => {
+                    'ssh-ca' => {
+                        keyPublic  => $ca_public_key,
+                        keyPrivate => $ca_private_key,
+                        keyComment => 'test ssh ca',
+                    }
+                },
+
+                # 'default' is a bastion group, so an enrolled server (which
+                # resolves to 'default' in legacy mode) counts as a bastion.
+                pamAccessBastionGroups => 'default,bastion',
+                pamAccessSshRules      => { default => '1' },
+                pamAccessBastionCertTtl => 120,
+            }
+        }
+    ),
+    'OP with pam-access + ssh-ca cert vouching'
+);
+
+# ============================================================================
+# Caller-gate error cases (no enrollment needed)
+# ============================================================================
+my $cert_body = to_json(
+    { user => 'french', target_host => 'b', public_key => $eph_pubkey } );
+
+# Without Bearer token
+ok(
+    $res = $op->_post(
+        '/pam/bastion-cert',
+        IO::String->new($cert_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($cert_body),
+    ),
+    'POST /pam/bastion-cert without Bearer'
+);
+is( $res->[0], 401, '  -> 401 without Bearer' );
+
+# With invalid Bearer token
+ok(
+    $res = $op->_post(
+        '/pam/bastion-cert',
+        IO::String->new($cert_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($cert_body),
+        custom => { HTTP_AUTHORIZATION => "Bearer invalid_xyz" },
+    ),
+    'POST /pam/bastion-cert with invalid Bearer'
+);
+is( $res->[0], 401, '  -> 401 with invalid Bearer' );
+
+# ============================================================================
+# Enroll a bastion, then run the real flow
+# ============================================================================
+my $id = $op->login('french');
+my $server_token = pam_lib::enroll_server( $op, $id );
+ok( $server_token, 'Got bastion server token' );
+
+# Helper: POST a JSON body to a pam endpoint with the bastion Bearer.
+sub bastion_post {
+    my ( $path, $hash ) = @_;
+    my $body = to_json($hash);
+    return $op->_post(
+        $path,
+        IO::String->new($body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($body),
+        custom => { HTTP_AUTHORIZATION => "Bearer $server_token" },
+    );
+}
+
+# --- /pam/authorize mints a (bastion_id, user) voucher -----------------------
+$res = bastion_post( '/pam/authorize',
+    { user => 'french', server_group => 'default', host => 'b1', service => 'ssh' } );
+is( $res->[0], 200, '/pam/authorize 200' );
+my $authz = from_json( $res->[2]->[0] );
+ok( $authz->{authorized}, '  -> authorized' );
+my $voucher = $authz->{bastion_voucher};
+ok( $voucher, '  -> bastion_voucher present' );
+
+# ============================================================================
+# Body-validation cases (with a valid Bearer)
+# ============================================================================
+
+# Missing user
+$res = bastion_post( '/pam/bastion-cert',
+    { target_host => 'b', public_key => $eph_pubkey, voucher => $voucher } );
+is( $res->[0], 400, 'bastion-cert without user -> 400' );
+
+# Missing public_key
+$res = bastion_post( '/pam/bastion-cert',
+    { user => 'french', target_host => 'b', voucher => $voucher } );
+is( $res->[0], 400, 'bastion-cert without public_key -> 400' );
+
+# Missing voucher
+$res = bastion_post( '/pam/bastion-cert',
+    { user => 'french', target_host => 'b', public_key => $eph_pubkey } );
+is( $res->[0], 400, 'bastion-cert without voucher -> 400' );
+
+# Malformed public key
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user        => 'french',
+        target_host => 'b',
+        public_key  => 'not-a-key',
+        voucher     => $voucher
+    }
+);
+is( $res->[0], 400, 'bastion-cert with malformed public_key -> 400' );
+
+# ============================================================================
+# SECURITY: voucher binding
+# ============================================================================
+
+# Wrong voucher value
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user        => 'french',
+        target_host => 'b',
+        public_key  => $eph_pubkey,
+        voucher     => 'deadbeef-0000'
+    }
+);
+is( $res->[0], 403, 'wrong voucher -> 403' );
+is( from_json( $res->[2]->[0] )->{reason},
+    'voucher_mismatch', '  -> reason voucher_mismatch' );
+
+# **KEY TEST**: a user the bastion never authorized (no voucher of their own)
+# cannot get a cert, even reusing another user's voucher value.
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user        => 'dwho',
+        target_host => 'b',
+        public_key  => $eph_pubkey,
+        voucher     => $voucher
+    }
+);
+is( $res->[0], 403, 'cert for non-vouched user (dwho) -> 403' );
+is( from_json( $res->[2]->[0] )->{error},
+    'voucher_rejected', '  -> voucher_rejected' );
+
+# ============================================================================
+# Successful issuance + cert contents
+# ============================================================================
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user         => 'french',
+        target_host  => 'backend1.op.com',
+        target_group => 'production',
+        public_key   => $eph_pubkey,
+        voucher      => $voucher,
+    }
+);
+is( $res->[0], 200, 'valid voucher -> 200 cert issued' );
+my $certresp = from_json( $res->[2]->[0] );
+ok( $certresp->{certificate}, '  -> certificate returned' );
+is(
+    $certresp->{key_id},
+    'bastion=pam-access;user=french;target=backend1.op.com',
+    '  -> key_id encodes bastion/user/target'
+);
+
+# Inspect the signed certificate with ssh-keygen -L
+SKIP: {
+    skip "no certificate to inspect", 3 unless $certresp->{certificate};
+    my $tmpdir = tempdir( CLEANUP => 1 );
+    open my $fh, '>', "$tmpdir/c-cert.pub" or die;
+    print $fh $certresp->{certificate};
+    close $fh;
+    my $L = `ssh-keygen -L -f $tmpdir/c-cert.pub 2>&1`;
+    like( $L, qr/Type:\s+\S+-cert-v01\@openssh\.com user certificate/,
+        '  -> is a user certificate' );
+    like( $L, qr/Principals:\s*\n\s+french\b/, '  -> principal is french' );
+    like( $L, qr/Key ID: "bastion=pam-access;user=french;target=backend1\.op\.com"/,
+        '  -> key-id present in cert' );
+}
+
+# Voucher is REUSABLE (not consumed) -> supports multi-hop / scp host1: host2:
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user        => 'french',
+        target_host => 'backend2.op.com',
+        public_key  => $eph_pubkey,
+        voucher     => $voucher,
+    }
+);
+is( $res->[0], 200, 'same voucher reused for a second hop -> 200' );
+
+done_testing();

--- a/plugins/pam-access/t/08-PamAccess-BastionCert.t
+++ b/plugins/pam-access/t/08-PamAccess-BastionCert.t
@@ -4,6 +4,7 @@ use strict;
 use IO::String;
 use JSON;
 use File::Temp qw(tempdir);
+use Time::Local qw(timelocal);
 
 BEGIN {
     require 't/test-lib.pm';
@@ -86,7 +87,14 @@ ok(
                 # resolves to 'default' in legacy mode) counts as a bastion.
                 pamAccessBastionGroups => 'default,bastion',
                 pamAccessSshRules      => { default => '1' },
-                pamAccessBastionCertTtl => 120,
+                # 90s (not a multiple of 60) so the issued cert can only
+                # come from the "+90s" $opts override, not the legacy
+                # minute-granularity argument.
+                pamAccessBastionCertTtl => 90,
+
+                # Deliberately invalid: minting must fall back to the 12h
+                # default instead of issuing dead vouchers.
+                pamAccessBastionVoucherTtl => 'twelve-hours',
             }
         }
     ),
@@ -223,6 +231,7 @@ is( from_json( $res->[2]->[0] )->{error},
 # ============================================================================
 # Successful issuance + cert contents
 # ============================================================================
+my $t_sign = time;
 $res = bastion_post(
     '/pam/bastion-cert',
     {
@@ -236,6 +245,7 @@ $res = bastion_post(
 is( $res->[0], 200, 'valid voucher -> 200 cert issued' );
 my $certresp = from_json( $res->[2]->[0] );
 ok( $certresp->{certificate}, '  -> certificate returned' );
+is( $certresp->{expires_in}, 90, '  -> expires_in is the configured TTL' );
 is(
     $certresp->{key_id},
     'bastion=pam-access;user=french;target=backend1.op.com',
@@ -244,7 +254,7 @@ is(
 
 # Inspect the signed certificate with ssh-keygen -L
 SKIP: {
-    skip "no certificate to inspect", 3 unless $certresp->{certificate};
+    skip "no certificate to inspect", 6 unless $certresp->{certificate};
     my $tmpdir = tempdir( CLEANUP => 1 );
     open my $fh, '>', "$tmpdir/c-cert.pub" or die;
     print $fh $certresp->{certificate};
@@ -255,6 +265,25 @@ SKIP: {
     like( $L, qr/Principals:\s*\n\s+french\b/, '  -> principal is french' );
     like( $L, qr/Key ID: "bastion=pam-access;user=french;target=backend1\.op\.com"/,
         '  -> key-id present in cert' );
+
+    # The _signSshKey $opts contract: source-address pins the cert to the
+    # vouching bastion's IP (test requests come from 127.0.0.1)...
+    like( $L, qr/source-address\s+127\.0\.0\.1/,
+        '  -> source-address critical option pins the bastion IP' );
+
+    # ...and validity carries the sub-minute "+90s" $opts override. OpenSSH
+    # backdates the start by a 60s clock-skew allowance rounded down to the
+    # minute, so only the end timestamp is assertable: it must land ~90s
+    # after the signing request (the legacy +2m path would give ~120s).
+    my ( $from, $to ) = $L =~ /Valid:\s+from\s+(\S+)\s+to\s+(\S+)/;
+    ok( $from && $to, '  -> validity window present' );
+    my $epoch = sub {
+        my @f = $_[0] =~ /(\d{4})-(\d\d)-(\d\d)T(\d\d):(\d\d):(\d\d)/;
+        return @f ? timelocal( @f[ 5, 4, 3 ], $f[2], $f[1] - 1, $f[0] ) : 0;
+    };
+    my $end = $epoch->($to) - $t_sign;
+    ok( $end >= 85 && $end <= 95,
+        "  -> cert expires ~90s after signing (got ${end}s)" );
 }
 
 # Voucher is REUSABLE (not consumed) -> supports multi-hop / scp host1: host2:
@@ -268,5 +297,50 @@ $res = bastion_post(
     }
 );
 is( $res->[0], 200, 'same voucher reused for a second hop -> 200' );
+
+# ============================================================================
+# Expired voucher -> 403 voucher_expired (client tells user to reconnect)
+# ============================================================================
+{
+    my $ps   = $op->p->getPersistentSession('french');
+    my $vmap = from_json( $ps->data->{_pamBastionVouchers} );
+    $_->{exp} = time - 10 for values %$vmap;
+    $ps->update( { _pamBastionVouchers => to_json($vmap) } );
+}
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user        => 'french',
+        target_host => 'b',
+        public_key  => $eph_pubkey,
+        voucher     => $voucher,
+    }
+);
+is( $res->[0], 403, 'expired voucher -> 403' );
+is( from_json( $res->[2]->[0] )->{reason},
+    'voucher_expired', '  -> reason voucher_expired' );
+
+# ============================================================================
+# Corrupted voucher map -> 500 (internal failure, not an authz denial)
+# ============================================================================
+{
+    my $ps = $op->p->getPersistentSession('french');
+    $ps->update( { _pamBastionVouchers => 'not-json{' } );
+}
+$res = bastion_post(
+    '/pam/bastion-cert',
+    {
+        user        => 'french',
+        target_host => 'b',
+        public_key  => $eph_pubkey,
+        voucher     => $voucher,
+    }
+);
+is( $res->[0], 500, 'corrupted voucher map -> 500' );
+{
+    my $err = from_json( $res->[2]->[0] );
+    is( $err->{error},  'voucher_check_failed', '  -> voucher_check_failed' );
+    is( $err->{reason}, 'voucher_corrupted',    '  -> reason voucher_corrupted' );
+}
 
 done_testing();

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -534,9 +534,20 @@ sub sshCaSign {
 }
 
 # HELPER: Sign SSH key using ssh-keygen
+#
+# $opts (optional hashref) lets callers other than the interactive /ssh/sign
+# route (e.g. pam-access bastion-cert vouching) tighten the certificate:
+#   - validity       : explicit ssh-keygen -V spec (e.g. "+120s"), overrides
+#                      the $validityMinutes argument. Enables sub-minute TTLs.
+#   - source_address : value for the `source-address` critical option. sshd
+#                      itself then refuses the cert unless the connection comes
+#                      from that address/CIDR. MUST be pre-validated by the
+#                      caller (passed verbatim to ssh-keygen -O).
 sub _signSshKey {
-    my ( $self, $userPubKey, $principals, $validityMinutes, $serial, $keyId ) =
-      @_;
+    my ( $self, $userPubKey, $principals, $validityMinutes, $serial, $keyId,
+        $opts )
+      = @_;
+    $opts ||= {};
 
     require File::Temp;
 
@@ -564,15 +575,23 @@ sub _signSshKey {
     close $fh;
 
     # Build ssh-keygen command
+    my $validitySpec = $opts->{validity} || "+${validityMinutes}m";
     my @cmd = (
         'ssh-keygen',
         '-s', $caKeyFile,                   # CA key
         '-I', $keyId,                       # Key identity
         '-n', join( ',', @$principals ),    # Principals
-        '-V', "+${validityMinutes}m",       # Validity
+        '-V', $validitySpec,                # Validity (override via $opts)
         '-z', $serial,                      # Serial number
-        $userKeyFile                        # User's public key to sign
     );
+
+    # Optional `source-address` critical option: sshd refuses the cert unless
+    # the connection originates from this address/CIDR. Used by bastion-cert
+    # vouching to pin a cert to the vouching bastion's IP.
+    push @cmd, '-O', "source-address=$opts->{source_address}"
+      if defined $opts->{source_address} && $opts->{source_address} ne '';
+
+    push @cmd, $userKeyFile;               # User's public key to sign (last)
 
     $self->logger->debug( "SSH CA: Running: " . join( ' ', @cmd ) );
 

--- a/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
+++ b/plugins/ssh-ca/lib/Lemonldap/NG/Portal/Plugins/SSHCA.pm
@@ -547,7 +547,7 @@ sub _signSshKey {
     my ( $self, $userPubKey, $principals, $validityMinutes, $serial, $keyId,
         $opts )
       = @_;
-    $opts ||= {};
+    $opts = {} unless ref $opts eq 'HASH';
 
     require File::Temp;
 


### PR DESCRIPTION
## Why

The bastion→backend "accept only this bastion" feature was **structurally broken**. `ob-ssh-proxy` requested a JWT from `POST /pam/bastion-token` and passed it backend-side via `ssh -o SendEnv=LLNG_BASTION_JWT`; `pam_openbastion` read it with `pam_getenv`. But `SendEnv`/`AcceptEnv` only populate the eventual **child process** environment, never the **PAM** environment that `pam_getenv` reads — at any stage. So a `bastion_jwt_required` backend rejected **every** session. There was no end-to-end test on the hop, so it shipped broken.

## What

Certificate-based vouching that needs **no user key on the bastion** and no agent forwarding:

- **`POST /pam/bastion-cert`** — a bastion sends an ephemeral public key + a per-`(bastion_id, user)` voucher; LLNG signs a short-lived user certificate with the **ssh-ca CA key** (reusing `SSHCA::_signSshKey`). The cert is:
  - pinned to the bastion IP via the `source-address` critical option (sshd-native enforcement);
  - tagged with `bastion=<id>;user=<u>;target=<host>` in the **key-id**, so the backend's `pam_openbastion` can enforce an allowed-bastions list;
  - `Principals: <user>`, short TTL (`pamAccessBastionCertTtl`, default 120s).

- **`/pam/authorize`** now mints a **reusable, session-scoped voucher** bound to `(bastion_id, user)` when the caller is a bastion group and the user is authorized. It proves the user actually connected to *this* bastion — closing the hole where a bastion could vouch for any user it never saw. Validity is capped by the user's SSO cert lifetime (via `_checkSshFingerprint`), else by `pamAccessBastionVoucherTtl` (default 12h). Reusable across hops (multiplexed connections, `scp host1: host2:` launched on the bastion); on expiry the proxy fails closed and asks the user to reconnect.

- **`SSHCA::_signSshKey`** gains an optional `$opts` hashref (`validity` for sub-minute TTLs, `source_address` for the critical option). The interactive `/ssh/sign` route is unchanged.

`/pam/bastion-token` is kept for backward-compat (deprecated).

## New config
- `pamAccessBastionCertTtl` (default 120s)
- `pamAccessBastionVoucherTtl` (default 43200s / 12h)

## Security property (validated live)
A bastion can obtain an ephemeral cert **only for a user it actually `/pam/authorize`d** (which minted that user's voucher under that `bastion_id`):

| Test | Result |
|------|--------|
| dwho valid voucher | `200` cert issued, key-id `bastion=pam-access;user=dwho;target=…`, `source-address` set, ~120s, CA-signed |
| reuse same voucher (multi-hop) | `200` (voucher is reusable, not consumed) |
| dwho wrong voucher | `403 voucher_mismatch` |
| **rtyler with dwho's voucher** | **`403 voucher_expired`** (voucher keyed by user) |
| missing voucher | `400` |

## Testing
- `perl -c` clean for both plugins.
- Live end-to-end against `yadd/lemonldap-ng-full` (authorize → voucher → bastion-cert → `ssh-keygen -L` inspection + the negative matrix above).
- Full SSH e2e (bastion→backend via the new `ob-ssh-proxy` / `pam_openbastion` / `ob-backend-setup`) lands in the companion open-bastion PR.

Design doc: `open-bastion/doc/design/bastion-cert-vouching.md`.