### PR TITLE
fix(oidc-device-authorization): apply getScope to device-grant tokens (S2)

### DIFF
--- a/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
+++ b/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
@@ -582,6 +582,17 @@ sub submitVerification {
     my $user_session_id = $req->id || $req->userData->{_session_id};
     my $user            = $req->userData->{ $self->conf->{whatToTrace} };
 
+    # Resolve the granted scope through the core gate now that we have the
+    # consenting user's context ($req->userData). The device endpoint is
+    # pre-auth, so the scope requested there is unfiltered; resolving it here
+    # applies declared-scope filtering (oidcServiceAllowOnlyDeclaredScopes) and
+    # the per-user dynamic scope rules (rpScopeRules) exactly like the
+    # authorization-code flow, so a device cannot obtain a privileged scope the
+    # approving user is not entitled to. offline_access is intentionally kept
+    # (it is the offline refresh-token marker, stripped later at token minting).
+    my $granted_scope =
+      $self->oidc->getScope( $req, $rp, $device_auth->{scope} );
+
     $self->_updateDeviceAuthStatus(
         $device_auth,
         'approved',
@@ -589,6 +600,7 @@ sub submitVerification {
             user_session_id => $user_session_id,
             user            => $user,
             approved_at     => time(),
+            scope           => $granted_scope,
         }
     );
 
@@ -611,7 +623,7 @@ sub submitVerification {
         params => {
             DEVICE_APPROVED => 1,
             CLIENT_ID       => $device_auth->{client_id},
-            SCOPE           => $device_auth->{scope},
+            SCOPE           => $granted_scope,
             MSG             => 'deviceApproved',
         }
     );

--- a/plugins/oidc-device-authorization/t/34-Device-Scope-Gating.t
+++ b/plugins/oidc-device-authorization/t/34-Device-Scope-Gating.t
@@ -1,0 +1,143 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+}
+
+my $debug = 'error';
+
+# The device endpoint is pre-auth, so the requested scope is unfiltered. The
+# plugin must resolve it through the core getScope gate at approval time, so
+# the per-user dynamic scope rules (rpScopeRules) decide which privileged
+# scopes the *approving* user actually grants — exactly like the
+# authorization-code flow. Here `pam` is granted only to dwho.
+
+my $op = LLNG::Manager::Test->new( {
+        ini => {
+            logLevel                        => $debug,
+            domain                          => 'op.com',
+            portal                          => 'http://auth.op.com/',
+            authentication                  => 'Demo',
+            userDB                          => 'Same',
+            issuerDBOpenIDConnectActivation => 1,
+            customPlugins => '::Plugins::OIDCDeviceAuthorization',
+            oidcServiceDeviceAuthorizationExpiration      => 600,
+            oidcServiceDeviceAuthorizationPollingInterval => 5,
+            oidcServiceDeviceAuthorizationUserCodeLength  => 8,
+            oidcRPMetaDataExportedVars => {
+                rp_scoped => { preferred_username => 'uid', name => 'cn' },
+            },
+            oidcRPMetaDataScopeRules => {
+
+                # `pam` is a dynamic scope granted only to dwho; `openid`
+                # stays untouched (not a dynamic scope).
+                rp_scoped => { pam => '$uid eq q{dwho}' },
+            },
+            oidcRPMetaDataOptions => {
+                rp_scoped => {
+                    oidcRPMetaDataOptionsDisplayName    => 'RP Scoped',
+                    oidcRPMetaDataOptionsIDTokenExpiration  => 3600,
+                    oidcRPMetaDataOptionsIDTokenSignAlg     => 'RS256',
+                    oidcRPMetaDataOptionsClientID           => 'rp_scoped',
+                    oidcRPMetaDataOptionsPublic             => 1,
+                    oidcRPMetaDataOptionsUserIDAttr         => '',
+                    oidcRPMetaDataOptionsAccessTokenExpiration     => 3600,
+                    oidcRPMetaDataOptionsBypassConsent             => 1,
+                    oidcRPMetaDataOptionsAllowDeviceAuthorization  => 1,
+                },
+            },
+            oidcServicePrivateKeySig => oidc_key_op_private_sig,
+            oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+        }
+    }
+);
+
+# ---------------------------------------------------------------------------
+# Helper: full device-authorization flow for a public client, approved by the
+# session $sid. Returns the decoded token JSON hashref, or dies.
+# ---------------------------------------------------------------------------
+sub device_flow {
+    my ( $client_id, $scope, $sid ) = @_;
+
+    my $query = buildForm( { client_id => $client_id, scope => $scope } );
+    my $res = $op->_post(
+        '/oauth2/device',
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+    );
+    die "device auth request failed ($res->[0])" unless $res->[0] == 200;
+
+    my $init = from_json( $res->[2]->[0] );
+    my $device_code = $init->{device_code} or die "no device_code";
+    ( my $user_code = $init->{user_code} ) =~ s/-//g;
+
+    $res = $op->_get(
+        '/device',
+        query  => "user_code=$user_code",
+        cookie => "lemonldap=$sid",
+        accept => 'text/html',
+    );
+    my ($csrf) = $res->[2]->[0] =~ m/name="token"\s+value="([^"]+)"/;
+    die "no CSRF token" unless $csrf;
+
+    $query = buildForm(
+        { user_code => $user_code, action => 'approve', token => $csrf } );
+    $res = $op->_post(
+        '/device',
+        IO::String->new($query),
+        cookie => "lemonldap=$sid",
+        accept => 'text/html',
+        length => length($query),
+    );
+    die "device approval failed ($res->[0])" unless $res->[0] == 200;
+
+    $query = buildForm( {
+            grant_type  => 'urn:ietf:params:oauth:grant-type:device_code',
+            device_code => $device_code,
+            client_id   => $client_id,
+        }
+    );
+    $res = $op->_post(
+        '/oauth2/token',
+        IO::String->new($query),
+        accept => 'application/json',
+        length => length($query),
+    );
+    die "token exchange failed ($res->[0])" unless $res->[0] == 200;
+
+    return from_json( $res->[2]->[0] );
+}
+
+# ===========================================================================
+# Case 1: french requests `openid pam` — french does NOT match the rule, so
+#         `pam` must be stripped from the granted scope.
+# ===========================================================================
+my $sid_french = login( $op, 'french' );
+my $tok;
+ok( $tok = device_flow( 'rp_scoped', 'openid pam', $sid_french ),
+    'french: device flow completed' );
+ok( $tok->{access_token}, '  -> access_token present' );
+like( $tok->{scope} // '', qr/\bopenid\b/, '  -> scope keeps openid' );
+unlike( $tok->{scope} // '', qr/\bpam\b/,
+    '  -> scope strips pam (french not entitled by rpScopeRules)' );
+count(4);
+
+# ===========================================================================
+# Case 2: dwho requests `openid pam` — dwho matches the rule, so `pam` is
+#         granted. Proves resolution is per-user, not a blanket strip.
+# ===========================================================================
+my $sid_dwho = login( $op, 'dwho' );
+ok( $tok = device_flow( 'rp_scoped', 'openid pam', $sid_dwho ),
+    'dwho: device flow completed' );
+like( $tok->{scope} // '', qr/\bpam\b/,
+    '  -> scope keeps pam (dwho entitled by rpScopeRules)' );
+count(2);
+
+clean_sessions();
+done_testing();


### PR DESCRIPTION
## Contexte

Suite de la revue sécurité des 4 plugins Open-Bastion. Item **S2** : le flux
device-grant n'appliquait pas le filtrage de scope du core.

## Problème

L'endpoint `/oauth2/device` est **pré-auth** : le `scope` y est demandé sans
contexte utilisateur. Le plugin le propageait **verbatim** jusqu'aux tokens,
sans jamais passer par `OpenIDConnect::getScope` — contrairement au flux
authorization-code. Conséquence : ni le filtrage des scopes déclarés
(`oidcServiceAllowOnlyDeclaredScopes`) ni surtout les **règles de scope
dynamiques par-utilisateur** (`rpScopeRules`) n'étaient évaluées pour les
tokens device-grant.

> **Note d'exploitabilité** : non exploitable sur les déploiements Open-Bastion,
> qui utilisent toujours le mapping `pamAccessServerGroups` — le `server_group`
> (qui donne les pouvoirs PAM/bastion) vient du `client_id`, pas du scope OIDC.
> Le risque ne se matérialiserait qu'en mode legacy couplé à une dépendance aux
> `rpScopeRules`. C'est donc de la **cohérence / défense en profondeur** avec le
> flux OIDC standard.

## Correctif

`submitVerification` résout désormais le scope demandé via `getScope` au moment
de l'**approbation**, où `$req->userData` est l'utilisateur consentant, et stocke
le scope résolu sur l'autorisation device. Un device ne peut donc plus obtenir
un scope privilégié que l'utilisateur approbateur n'a pas le droit d'accorder.

`offline_access` est volontairement conservé par `getScope` (c'est le marqueur de
refresh token offline) et reste stripé plus tard au minting (fix M1, déjà mergé).

## Tests

Nouveau `t/34-Device-Scope-Gating.t` : un RP déclare un scope dynamique `pam`
accordé uniquement à `dwho`.
- `french` demande `openid pam` et approuve → `pam` retiré, `openid` conservé
- `dwho` demande `openid pam` et approuve → `pam` accordé

Prouve que la résolution est bien par-utilisateur, pas un strip aveugle.
Suites complètes au vert : oidc-device-authorization (170), pam-access (502).

## Note de déploiement

Changement de comportement aligné sur le flux authorization-code : si
`oidcServiceAllowOnlyDeclaredScopes` est activé, les scopes utilisés par les
serveurs (`pam` / `pam:server`) doivent être **déclarés** pour le RP (via
`oidcRPMetaDataScopeRules` ou les scopes statiques), sinon ils seront filtrés.

Pas de bump de version (release séparée).