### PR TITLE
feat(pam-access): store connected users from heartbeat

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1024,6 +1024,15 @@ sub heartbeat {
         $updates->{_pamStats} = to_json( $body->{stats} );
     }
 
+    # Store the list of users currently connected on this machine ("who is
+    # connected"), reported by ob-heartbeat. Kept as a JSON string alongside a
+    # quick-access count, on the same model as _pamStats.
+    if ( $body->{sessions} ) {
+        $updates->{_pamSessions} = to_json( $body->{sessions} );
+        $updates->{_pamSessionCount} =
+          ref $body->{sessions} eq 'ARRAY' ? scalar @{ $body->{sessions} } : 0;
+    }
+
     # First heartbeat = enrollment timestamp
     unless ( $rtSession->data->{_pamEnrolledAt} ) {
         $updates->{_pamEnrolledAt} = $now;

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1025,12 +1025,18 @@ sub heartbeat {
     }
 
     # Store the list of users currently connected on this machine ("who is
-    # connected"), reported by ob-heartbeat. Kept as a JSON string alongside a
-    # quick-access count, on the same model as _pamStats.
+    # connected"), reported by ob-heartbeat. Always persist a JSON array so
+    # consumers can rely on _pamSessions being an array consistent with
+    # _pamSessionCount; coerce a malformed (non-array) payload to an empty list.
     if ( $body->{sessions} ) {
-        $updates->{_pamSessions} = to_json( $body->{sessions} );
-        $updates->{_pamSessionCount} =
-          ref $body->{sessions} eq 'ARRAY' ? scalar @{ $body->{sessions} } : 0;
+        my $sessions = $body->{sessions};
+        unless ( ref $sessions eq 'ARRAY' ) {
+            $self->logger->warn(
+                'PAM heartbeat: ignoring malformed "sessions" (not an array)');
+            $sessions = [];
+        }
+        $updates->{_pamSessions}     = to_json($sessions);
+        $updates->{_pamSessionCount} = scalar @$sessions;
     }
 
     # First heartbeat = enrollment timestamp

--- a/plugins/pam-access/t/07-PamAccess-Heartbeat.t
+++ b/plugins/pam-access/t/07-PamAccess-Heartbeat.t
@@ -246,5 +246,71 @@ ok(
 is( $res->[0], 401, 'Invalid refresh_token yields HTTP 401' );
 count(2);
 
+# ===========================================================================
+# Test 6: connected sessions are persisted into the refresh-token session
+# ===========================================================================
+
+my $sess_body = to_json( {
+        refresh_token => $rt,
+        hostname      => 'srv1.example.com',
+        server_group  => 'default',
+        sessions      => [
+            { user => 'dwho', from => '10.0.0.5', tty => 'pts/0', since => 1700000000 },
+            { user => 'rtyler', from => '', tty => 'tty1', since => 1700000100 },
+        ],
+    }
+);
+ok(
+    $res = $op->_post(
+        '/pam/heartbeat',
+        IO::String->new($sess_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($sess_body),
+    ),
+    'POST /pam/heartbeat with sessions list'
+);
+expectOK($res);
+count(1);
+
+$rt_session = $oidc_mod->getRefreshToken($rt);
+ok( $rt_session->data->{_pamSessions}, '_pamSessions stored in refresh session' );
+is( $rt_session->data->{_pamSessionCount}, 2, '_pamSessionCount matches list length' );
+my $stored = from_json( $rt_session->data->{_pamSessions} );
+is( ref $stored,            'ARRAY', '_pamSessions decodes to a JSON array' );
+is( $stored->[0]->{user},   'dwho',  'first session user persisted' );
+is( $stored->[0]->{from},   '10.0.0.5', 'first session source host persisted' );
+is( $stored->[1]->{tty},    'tty1',  'second session tty persisted' );
+count(6);
+
+# ===========================================================================
+# Test 7: malformed "sessions" (not an array) is coerced to an empty list
+# ===========================================================================
+
+my $bad_sess_body = to_json( {
+        refresh_token => $rt,
+        hostname      => 'srv1.example.com',
+        server_group  => 'default',
+        sessions      => 'not-an-array',
+    }
+);
+ok(
+    $res = $op->_post(
+        '/pam/heartbeat',
+        IO::String->new($bad_sess_body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($bad_sess_body),
+    ),
+    'POST /pam/heartbeat with malformed sessions'
+);
+expectOK($res);
+count(1);
+
+$rt_session = $oidc_mod->getRefreshToken($rt);
+is( $rt_session->data->{_pamSessions}, '[]', 'malformed sessions coerced to empty JSON array' );
+is( $rt_session->data->{_pamSessionCount}, 0, 'malformed sessions yields count 0' );
+count(2);
+
 clean_sessions();
 done_testing();


### PR DESCRIPTION
## Summary

Server-side counterpart for "who is connected on this machine".

The `/pam/heartbeat` endpoint now persists the `sessions` array reported by `ob-heartbeat` (the list of users currently connected on a server) into the refresh-token session:

- `_pamSessions` — the session list as a JSON string
- `_pamSessionCount` — a quick-access count

This follows the exact model of the existing `_pamStats` field, so administrators can see active sessions per machine. No new route or config is required.

## Companion PR

Client-side collection lives in **linagora/open-bastion** (`feat/heartbeat-connected-sessions`), where `ob-heartbeat` gathers sessions via `loginctl`/`who` and adds them to the heartbeat payload. Both PRs are needed for the end-to-end feature.

## Tests

- `perl -c` on `PamAccess.pm` (with LLNG `blib/lib`) → syntax OK ✅
- Storage logic validated standalone: `to_json` of the array + count + defensive guard for a non-array `sessions` value ✅

Remaining: end-to-end validation on the 3-VM lab.