### PR TITLE
feat(pam-access): store node role from heartbeat

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1014,6 +1014,7 @@ sub heartbeat {
         _pamHostname    => $hostname,
         _pamServerGroup => $body->{server_group} || 'default',
         _pamVersion     => $body->{version}      || '',
+        _pamNodeRole    => $body->{node_role}    || '',
         _pamLastSeen    => $now,
         _pamStatus      => 'active',
         _utime          => $now + $offlineExp - $self->conf->{timeout},

--- a/plugins/pam-access/t/07-PamAccess-Heartbeat.t
+++ b/plugins/pam-access/t/07-PamAccess-Heartbeat.t
@@ -141,6 +141,8 @@ my $hb_body = to_json( {
         refresh_token => $rt,
         hostname      => 'srv1.example.com',
         server_group  => 'default',
+        version       => '0.3.0',
+        node_role     => 'bastion',
     }
 );
 ok(
@@ -197,7 +199,9 @@ count(2);
 my $oidc_mod = $op->p->loadedModules->{'Lemonldap::NG::Portal::Issuer::OpenIDConnect'};
 my $rt_session = $oidc_mod->getRefreshToken($rt);
 ok( $rt_session, 'Can read refresh token session after heartbeat' );
-count(1);
+is( $rt_session->data->{_pamVersion},  '0.3.0',   'client version stored as _pamVersion' );
+is( $rt_session->data->{_pamNodeRole}, 'bastion', 'node role stored as _pamNodeRole' );
+count(3);
 
 my $utime   = $rt_session->data->{_utime};
 my $offline_exp = 2592000;


### PR DESCRIPTION
## Summary

Follow-up to #32. Persist the `node_role` reported by `ob-heartbeat` (`bastion` | `standalone` | `backend`) as **`_pamNodeRole`** in the refresh-token session, next to the existing `_pamVersion`, so the SSO can show what each enrolled machine runs.

## Companion PR

Client side is **linagora/open-bastion** PR #138 (`feat/heartbeat-connected-sessions`): `ob-heartbeat` now sends `version` (bumped to 0.3.0) and `node_role`, the latter written into `openbastion.conf` by the setup scripts (`--node-role`, defaulting to bastion/backend; the shell installer passes the builder's target role so standalone is recorded).

## Tests

`t/07-PamAccess-Heartbeat.t` asserts `_pamVersion` and `_pamNodeRole` are stored. Full suite via `node mcp/cli.js test pam-access`: **46/46 passing**.