### PR TITLE
fix(pam-access): stop gating bastion endpoints on the caller's server_group

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1251,35 +1251,17 @@ sub bastionToken {
         return $self->_forbiddenResponse( $req, 'Invalid token scope' );
     }
 
-    # 4. Resolve this server's authoritative group.
-    # In legacy mode (no pamAccessServerGroups mapping), preserve the
-    # prior behaviour of reading `server_group` from the access-token
-    # session, so deployments that populate it out-of-band keep working.
-    my $bastion_id    = $tokenSession->data->{client_id} || 'unknown';
-    my $session_group = $tokenSession->data->{server_group};
-    my $server_group =
-      $self->_resolveServerGroup( $req, $bastion_id, $session_group,
-        'PAM bastion-token' );
-    if ( ref $server_group eq 'HASH' && $server_group->{rejected} ) {
-        return $self->_forbiddenResponse( $req, $server_group->{message} );
-    }
-
-    my $bastion_groups = $self->conf->{pamAccessBastionGroups} || 'bastion';
-    my @allowed_groups = split /[,;\s]+/, $bastion_groups;
-    my $is_bastion     = 0;
-    for my $allowed (@allowed_groups) {
-        if ( $server_group eq $allowed ) {
-            $is_bastion = 1;
-            last;
-        }
-    }
-    unless ($is_bastion) {
-        $self->logger->warn(
-"PAM bastion-token: Server group '$server_group' is not a bastion group"
-        );
-        return $self->_forbiddenResponse( $req,
-            "Server is not an authorized bastion (group: $server_group)" );
-    }
+    # 4. Identify the calling server.
+    # bastion_id is the OIDC client_id, which in this model identifies a
+    # *project* (it enrolls every machine of the project) — it is set at RP
+    # registration and cannot be forged by the host. We do NOT gate this
+    # endpoint on a "bastion group": with a project-wide client_id the
+    # device-grant session carries no per-host server_group (it would resolve to
+    # "default" and reject every probe). The caller already proved it holds a
+    # valid device-grant token with the pam scope (steps 1-3), which is all that
+    # is required to learn its own bastion_id. The bastion-group distinction is
+    # enforced where it matters — voucher minting in /pam/authorize — not here.
+    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
 
     # 5. Parse JSON request body
     my $body = eval { from_json( $req->content ) };
@@ -1291,14 +1273,18 @@ sub bastionToken {
     my $user         = $body->{user};
     my $target_host  = $body->{target_host}  || '';
     my $target_group = $body->{target_group} || 'default';
+    # Informational only (audit logs / probe response): the group the caller
+    # claims for itself. Not a security control — see step 4.
+    my $server_group =
+      $body->{bastion_group} || $tokenSession->data->{server_group} || 'default';
 
     # Probe mode (ob-bastion-id): a server self-identifying the bastion_id it
     # would receive does not vouch for any real user, so the per-user _pamSeen
-    # recency gate below does not apply, and no `user` is required. Steps 1-4
-    # already proved the caller holds a valid device-grant token for a group
-    # listed in pamAccessBastionGroups — which is exactly what authorises it
-    # to learn its own bastion_id. We return the identifier only, never a
-    # usable JWT, so probe mode cannot be abused to mint credentials.
+    # recency gate below does not apply, and no `user` is required. Steps 1-3
+    # already proved the caller holds a valid device-grant token with the pam
+    # scope — which is all that is required to learn its own bastion_id. We
+    # return the identifier only, never a usable JWT, so probe mode cannot be
+    # abused to mint credentials.
     if ( $body->{probe} ) {
         $self->logger->info( "PAM bastion-token: probe request — "
               . "returning bastion_id '$bastion_id' (group=$server_group)" );
@@ -1916,20 +1902,20 @@ sub bastionCert {
     return $self->_forbiddenResponse( $req, 'Invalid token scope' )
       unless $scope =~ /\bpam(?::server)?\b/;
 
-    my $bastion_id    = $tokenSession->data->{client_id} || 'unknown';
-    my $session_group = $tokenSession->data->{server_group};
-    my $server_group =
-      $self->_resolveServerGroup( $req, $bastion_id, $session_group,
-        'PAM bastion-cert' );
-    return $self->_forbiddenResponse( $req, $server_group->{message} )
-      if ref $server_group eq 'HASH' && $server_group->{rejected};
+    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
 
-    unless ( $self->_isBastionGroup($server_group) ) {
-        $self->logger->warn( "PAM bastion-cert: server group '$server_group' "
-              . "is not a bastion group" );
-        return $self->_forbiddenResponse( $req,
-            "Server is not an authorized bastion (group: $server_group)" );
-    }
+    # NB: we deliberately do NOT re-derive or require a "bastion group" here.
+    # The only security property that matters at this endpoint — a bastion may
+    # mint a certificate ONLY for a user who actually connected to it — is
+    # carried entirely by the voucher checked below. That voucher is minted by
+    # /pam/authorize ONLY for a host whose server_group is in
+    # pamAccessBastionGroups, and it binds (bastion_id, user); so its mere
+    # existence already proves the caller was a legitimate bastion at connection
+    # time. Re-checking the group from the access-token session here was both
+    # redundant and wrong for the intended model (one OIDC client_id per
+    # *project*, with finer-grained PAM groups inside it): the device-grant
+    # session carries no per-host server_group, so it always resolved to
+    # "default" and rejected every legitimate hop.
 
     # 5. Parse + validate request body.
     my $body = eval { from_json( $req->content ) };

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1273,10 +1273,21 @@ sub bastionToken {
     my $user         = $body->{user};
     my $target_host  = $body->{target_host}  || '';
     my $target_group = $body->{target_group} || 'default';
-    # Informational only (audit logs / probe response): the group the caller
-    # claims for itself. Not a security control — see step 4.
+    # Informational only (audit logs / probe response / JWT claims): not a
+    # security control for *this* endpoint — see step 4. We still resolve it
+    # through pamAccessServerGroups rather than trusting the request body
+    # blindly: when the client_id->group mapping is configured the resolved
+    # group is authoritative (and an unmapped/mismatched caller is rejected,
+    # as in /pam/authorize), so we never sign a caller-forged group into the
+    # JWT; in legacy mode (empty mapping) we fall back to the caller-claimed
+    # value, exactly as /pam/authorize does.
     my $server_group =
-      $body->{bastion_group} || $tokenSession->data->{server_group} || 'default';
+      $self->_resolveServerGroup( $req, $bastion_id,
+        $body->{bastion_group} || $tokenSession->data->{server_group},
+        'PAM bastion-token' );
+    if ( ref $server_group eq 'HASH' && $server_group->{rejected} ) {
+        return $self->_forbiddenResponse( $req, $server_group->{message} );
+    }
 
     # Probe mode (ob-bastion-id): a server self-identifying the bastion_id it
     # would receive does not vouch for any real user, so the per-user _pamSeen
@@ -1883,8 +1894,9 @@ sub _checkBastionVoucher {
 sub bastionCert {
     my ( $self, $req ) = @_;
 
-    # 1-4. Same caller gates as bastionToken: valid device-grant token, pam
-    #      scope, and a resolved server_group that is a bastion group.
+    # 1-3. Same caller gates as bastionToken: a valid device-grant token with
+    #      the pam scope. We do NOT require any "bastion group" here (see NB
+    #      below); the voucher checked in step 6 is the sole authorization.
     my $access_token = $self->oidc->getEndPointAccessToken($req);
     return $self->_unauthorizedResponse( $req, 'Bearer token required' )
       unless $access_token;
@@ -1908,10 +1920,14 @@ sub bastionCert {
     # The only security property that matters at this endpoint — a bastion may
     # mint a certificate ONLY for a user who actually connected to it — is
     # carried entirely by the voucher checked below. That voucher is minted by
-    # /pam/authorize ONLY for a host whose server_group is in
+    # /pam/authorize ONLY for a host whose resolved server_group is in
     # pamAccessBastionGroups, and it binds (bastion_id, user); so its mere
-    # existence already proves the caller was a legitimate bastion at connection
-    # time. Re-checking the group from the access-token session here was both
+    # existence proves the caller was treated as a bastion at connection time.
+    # (How strong that proof is depends on configuration: when
+    # pamAccessServerGroups maps client_id->group the group is authoritative;
+    # in legacy mode, with that mapping empty, /pam/authorize trusts the
+    # caller-provided server_group, so configure the mapping to harden this.)
+    # Re-checking the group from the access-token session here was both
     # redundant and wrong for the intended model (one OIDC client_id per
     # *project*, with finer-grained PAM groups inside it): the device-grant
     # session carries no per-host server_group, so it always resolved to

--- a/plugins/pam-access/t/04-PamAccess-BastionToken.t
+++ b/plugins/pam-access/t/04-PamAccess-BastionToken.t
@@ -265,6 +265,93 @@ is( $payload->{target_host},  '', 'Default target_host is empty' );
 is( $payload->{target_group}, 'default', 'Default target_group is "default"' );
 count(2);
 
+# ============================================================================
+# Authoritative server_group resolution (pamAccessServerGroups configured)
+# ----------------------------------------------------------------------------
+# When the client_id->group mapping is configured, the JWT's bastion_group
+# claim must come from the mapping, never from the caller-provided request
+# body: /pam/bastion-token treats the group as informational, but it still must
+# not sign a value the caller could forge. A body group that contradicts the
+# mapping is rejected exactly as in /pam/authorize.
+# ============================================================================
+{
+    my $op2;
+    ok(
+        $op2 = LLNG::Manager::Test->new( {
+                ini => {
+                    logLevel => $debug,
+                    domain   => 'op.com',
+                    portal   => 'http://auth.op.com',
+                    pam_lib::base_config(),
+                    pamAccessSshRules      => { default => '1' },
+                    pamAccessBastionGroups => 'bastion',
+                    pamAccessBastionJwtTtl => 300,
+
+                    # The enrolled server (client_id 'pam-access') is
+                    # authoritatively mapped to the 'bastion' group.
+                    pamAccessServerGroups => { 'pam-access' => 'bastion' },
+                }
+            }
+        ),
+        'OP with pamAccessServerGroups mapping'
+    );
+
+    my $id2  = $op2->login('french');
+    my $tok2 = pam_lib::enroll_server( $op2, $id2 );
+    ok( $tok2, 'Got server token (mapped OP)' );
+    count(1);
+
+    # Stamp the _pamSeen marker for 'french' (as the real /pam flow would).
+    {
+        my $q = 'duration=60';
+        my $r = $op2->_post(
+            '/pam',
+            IO::String->new($q),
+            accept => 'application/json',
+            cookie => "lemonldap=$id2",
+            length => length($q),
+        );
+        expectOK($r);
+    }
+
+    # A caller-forged bastion_group that contradicts the mapping is rejected.
+    my $forged = to_json(
+        { user => 'french', bastion_group => 'evil-forged-group' } );
+    ok(
+        $res = $op2->_post(
+            '/pam/bastion-token',
+            IO::String->new($forged),
+            accept => 'application/json',
+            type   => 'application/json',
+            length => length($forged),
+            custom => { HTTP_AUTHORIZATION => "Bearer $tok2" },
+        ),
+        'POST /pam/bastion-token with a forged bastion_group'
+    );
+    expectReject( $res, 403 );
+
+    # Without a contradicting body group, the JWT carries the *mapped* group.
+    my $ok_body = to_json( { user => 'french' } );
+    ok(
+        $res = $op2->_post(
+            '/pam/bastion-token',
+            IO::String->new($ok_body),
+            accept => 'application/json',
+            type   => 'application/json',
+            length => length($ok_body),
+            custom => { HTTP_AUTHORIZATION => "Bearer $tok2" },
+        ),
+        'POST /pam/bastion-token (mapped OP) succeeds'
+    );
+    expectOK($res);
+    my $j2 = expectJSON($res);
+    my @p2 = split /\./, $j2->{bastion_jwt};
+    my $pl2 = from_json( decode_base64url( $p2[1] ) );
+    is( $pl2->{bastion_group}, 'bastion',
+        'JWT bastion_group is the authoritative mapped value' );
+    count(1);
+}
+
 clean_sessions();
 done_testing();
 

--- a/plugins/pam-access/t/08-PamAccess-BastionCert.t
+++ b/plugins/pam-access/t/08-PamAccess-BastionCert.t
@@ -83,10 +83,15 @@ ok(
                     }
                 },
 
-                # 'default' is a bastion group, so an enrolled server (which
-                # resolves to 'default' in legacy mode) counts as a bastion.
-                pamAccessBastionGroups => 'default,bastion',
-                pamAccessSshRules      => { default => '1' },
+                # 'default' is deliberately NOT a bastion group. An enrolled
+                # server resolves to 'default' in legacy mode (no per-host
+                # server_group in the device-grant session — the realistic case
+                # with one project-wide client_id), so this proves /pam/bastion-
+                # cert and /pam/bastion-token no longer gate on the caller's
+                # group: the voucher (minted only when the caller authorizes with
+                # a real bastion group) is the sole security control.
+                pamAccessBastionGroups => 'bastion',
+                pamAccessSshRules      => { default => '1', bastion => '1' },
                 # Pin issued certs to the bastion IP (off by default); the
                 # "pin disabled" block below overrides this back to 0.
                 pamAccessBastionCertPinSourceAddress => 1,
@@ -160,7 +165,7 @@ sub bastion_post {
 
 # --- /pam/authorize mints a (bastion_id, user) voucher -----------------------
 $res = bastion_post( '/pam/authorize',
-    { user => 'french', server_group => 'default', host => 'b1', service => 'ssh' } );
+    { user => 'french', server_group => 'bastion', host => 'b1', service => 'ssh' } );
 is( $res->[0], 200, '/pam/authorize 200' );
 my $authz = from_json( $res->[2]->[0] );
 ok( $authz->{authorized}, '  -> authorized' );
@@ -313,14 +318,14 @@ SKIP: {
         '  -> entry is short-lived (cert TTL)' );
 
     # Integration: the backend's /pam/authorize with that fingerprint is now
-    # authorized (previously denied as fingerprint not-found). 'default' is a
-    # bastion group here, so this mints a fresh voucher — capture it so the
+    # authorized (previously denied as fingerprint not-found). 'bastion' is a
+    # real bastion group, so this mints a fresh voucher — capture it so the
     # voucher-reuse tests below keep working.
     $res = bastion_post(
         '/pam/authorize',
         {
             user         => 'french',
-            server_group => 'default',
+            server_group => 'bastion',
             host         => 'backend1.op.com',
             service      => 'ssh',
             fingerprint  => $eph_fp,
@@ -336,7 +341,7 @@ SKIP: {
         '/pam/authorize',
         {
             user         => 'french',
-            server_group => 'default',
+            server_group => 'bastion',
             host         => 'backend1.op.com',
             service      => 'ssh',
             fingerprint  => 'SHA256:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',


### PR DESCRIPTION
## Problem

With a single OIDC `client_id` **per project**, the device-grant session is shared by every machine of the project and therefore carries **no** per-host `server_group`. The "bastion group" check in `/pam/bastion-token` and `/pam/bastion-cert` thus always fell back to `default` via `_resolveServerGroup`, and **rejected every legitimate bastion hop**.

## Change

Drop the group gating at both endpoints. The security property — *a bastion may only mint credentials for a user who actually connected to it* — is carried entirely by the `(bastion_id, user)` **voucher**:

- the voucher is minted in `/pam/authorize` **only** when `_isBastionGroup($server_group)` is true, where `$server_group` comes from the *per-host* enrolled identity (`_resolveServerGroup`), not from the device-grant session;
- `/pam/bastion-cert` verifies this voucher (`_checkBastionVoucher`); its mere existence already proves the caller was a legitimate bastion at connection time.

`_resolveServerGroup` / `_isBastionGroup` are still used in `/pam/authorize` — no dead code. In `/pam/bastion-token`, `server_group` becomes **informational** (audit logs, probe response, JWT claims), no longer a security value.

## Tests

`08-PamAccess-BastionCert.t` reconfigured with `pamAccessBastionGroups => 'bastion'` (so `default` is **no longer** a bastion group), which proves the endpoints no longer gate on the caller's group.

```
node mcp/cli.js test pam-access  →  Files=8, Tests=525, Result: PASS
```