### PR TITLE
feat(pam-access): per-device bastion_id under a shared (project-wide) client_id

### DIFF
--- a/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
+++ b/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
@@ -878,6 +878,14 @@ sub _generateTokens {
     $access_token_extra->{user_session_id} = $user_session_id
       if $user_session_id;
 
+    # Propagate a per-device identifier set by the grant hook (e.g.
+    # oidc-device-organization stamps the synthetic session id as _deviceId) into
+    # the access token session, so consumers can identify the individual enrolled
+    # device. newAccessToken() only persists $access_token_extra, not arbitrary
+    # $session_data keys, hence this explicit forward.
+    $access_token_extra->{_deviceId} = $session_data->{_deviceId}
+      if $session_data->{_deviceId};
+
     my $access_token =
       $self->oidc->newAccessToken( $req, $rp, $scope, $session_data,
         $access_token_extra );

--- a/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
+++ b/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
@@ -92,8 +92,11 @@ sub handleOrganizationDevice {
         return PE_OK;    # Fall back to normal user-linked behavior
     }
 
-    # Point to the new synthetic session instead of the admin's
-    $device_auth->{user_session_id} = $session->id;
+    # Point to the new synthetic session instead of the admin's. Its id is also a
+    # stable, unique-per-device identifier (one synthetic session per enrolled
+    # device), reused below as the device-id carried in the tokens.
+    my $device_id = $session->id;
+    $device_auth->{user_session_id} = $device_id;
 
     # NOTE: we deliberately KEEP offline_access in the scope so the device
     # gets a long-lived *offline* refresh token (the durable machine identity,
@@ -109,6 +112,12 @@ sub handleOrganizationDevice {
 
     # Replace session_data so tokens carry synthetic attributes
     %$session_data = %{ $session->data };
+
+    # Stable, unique per-device identifier carried into every token derived from
+    # this enrollment (access + refresh), so downstream consumers (PamAccess
+    # bastion vouching) can identify the individual device — not just its shared,
+    # project-wide client_id.
+    $session_data->{_deviceId} = $device_id;
 
     $self->userLogger->notice(
 "Organization device enrolled: client=$client_id for RP $rp (approved by $approved_by)"

--- a/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
+++ b/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
@@ -123,7 +123,13 @@ sub handleOrganizationDevice {
     # session id is a live credential — anyone who learned it could replay it as
     # a `lemonldap` cookie and impersonate the synthetic session. The digest is
     # deterministic (stable across refreshes), unique per device, and one-way.
-    $session_data->{_deviceId} = sha256_hex( $session->id );
+    #
+    # The fixed prefix is domain separation: with hashedSessionStore enabled the
+    # backend storage key is itself sha256_hex(session id), so a bare
+    # sha256_hex(session id) here would equal that internal key. Prefixing
+    # guarantees the exposed device-id can never coincide with a LLNG storage
+    # key, in either storage mode.
+    $session_data->{_deviceId} = sha256_hex( 'pam-device-id:' . $session->id );
 
     $self->userLogger->notice(
 "Organization device enrolled: client=$client_id for RP $rp (approved by $approved_by)"

--- a/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
+++ b/plugins/oidc-device-organization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceOrganization.pm
@@ -16,6 +16,7 @@ package Lemonldap::NG::Portal::Plugins::OIDCDeviceOrganization;
 
 use strict;
 use Mouse;
+use Digest::SHA qw(sha256_hex);
 use Lemonldap::NG::Portal::Main::Constants qw(PE_OK);
 
 our $VERSION = '2.23.0';
@@ -92,11 +93,11 @@ sub handleOrganizationDevice {
         return PE_OK;    # Fall back to normal user-linked behavior
     }
 
-    # Point to the new synthetic session instead of the admin's. Its id is also a
-    # stable, unique-per-device identifier (one synthetic session per enrolled
-    # device), reused below as the device-id carried in the tokens.
-    my $device_id = $session->id;
-    $device_auth->{user_session_id} = $device_id;
+    # Point to the new synthetic session instead of the admin's (its real id is
+    # used for session lookups). One synthetic session is created per enrolled
+    # device, so it is also a stable, unique-per-device anchor — but we never
+    # expose the raw session id: see _deviceId below.
+    $device_auth->{user_session_id} = $session->id;
 
     # NOTE: we deliberately KEEP offline_access in the scope so the device
     # gets a long-lived *offline* refresh token (the durable machine identity,
@@ -116,8 +117,13 @@ sub handleOrganizationDevice {
     # Stable, unique per-device identifier carried into every token derived from
     # this enrollment (access + refresh), so downstream consumers (PamAccess
     # bastion vouching) can identify the individual device — not just its shared,
-    # project-wide client_id.
-    $session_data->{_deviceId} = $device_id;
+    # project-wide client_id. We derive it as a SHA-256 digest of the synthetic
+    # session id rather than exposing the id itself: the value is surfaced in
+    # tokens and API responses (e.g. the /pam/bastion-token probe), and the raw
+    # session id is a live credential — anyone who learned it could replay it as
+    # a `lemonldap` cookie and impersonate the synthetic session. The digest is
+    # deterministic (stable across refreshes), unique per device, and one-way.
+    $session_data->{_deviceId} = sha256_hex( $session->id );
 
     $self->userLogger->notice(
 "Organization device enrolled: client=$client_id for RP $rp (approved by $approved_by)"

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1264,18 +1264,19 @@ sub bastionToken {
     }
 
     # 4. Identify the calling server.
-    # bastion_id is the OIDC client_id, which in this model identifies a
-    # *project* (it enrolls every machine of the project) — it is set at RP
-    # registration and cannot be forged by the host. We do NOT gate this
-    # endpoint on a "bastion group": with a project-wide client_id the
-    # device-grant session carries no per-host server_group (it would resolve to
-    # "default" and reject every probe). The caller already proved it holds a
-    # valid device-grant token with the pam scope (steps 1-3), which is all that
-    # is required to learn its own bastion_id. The bastion-group distinction is
-    # enforced where it matters — voucher minting in /pam/authorize — not here.
-    # Prefer the per-device identifier (stamped at enrollment by the
-    # oidc-device-organization plugin) so a project-wide client_id still yields a
-    # unique id per bastion; fall back to client_id for legacy enrollments.
+    # bastion_id is taken from the device-grant token session and cannot be
+    # forged by the host: we prefer the per-device identifier `_deviceId`
+    # (stamped at enrollment by oidc-device-organization) so that a project-wide
+    # client_id — which enrolls every machine of the project and so identifies
+    # only the *project* — still yields an id unique per bastion; we fall back
+    # to client_id for legacy enrollments that carry no _deviceId.
+    # We do NOT gate this endpoint on a "bastion group": with a project-wide
+    # client_id the device-grant session carries no per-host server_group (it
+    # would resolve to "default" and reject every probe). The caller already
+    # proved it holds a valid device-grant token with the pam scope (steps 1-3),
+    # which is all that is required to learn its own bastion_id. The
+    # bastion-group distinction is enforced where it matters — voucher minting
+    # in /pam/authorize — not here.
     my $bastion_id = $tokenSession->data->{_deviceId}
       || $tokenSession->data->{client_id}
       || 'unknown';

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -278,8 +278,13 @@ sub authorize {
         return $self->_forbiddenResponse( $req, 'Invalid token scope' );
     }
 
-    # Log server identity from token
-    my $server_id = $tokenSession->data->{client_id} || 'unknown';
+    # Log server identity from token. Prefer the per-device id (stamped at
+    # enrollment by oidc-device-organization) so the voucher we mint binds to the
+    # individual bastion, matching what /pam/bastion-cert checks; fall back to
+    # client_id for legacy enrollments.
+    my $server_id = $tokenSession->data->{_deviceId}
+      || $tokenSession->data->{client_id}
+      || 'unknown';
     $self->logger->info(
         "PAM authorize request from enrolled server: $server_id");
 
@@ -1063,9 +1068,16 @@ sub heartbeat {
     #    the server's identity self-contained (RFC spirit: short access token,
     #    long refresh token, refresh loop driven by the device).
     my $scope = $rtSession->data->{scope} || '';
+    # Carry the per-device identifier across refreshes: newAccessToken() only
+    # persists this $info hash, not arbitrary $rtSession->data keys, so without
+    # this the bastion_id would revert to the shared client_id after the first
+    # heartbeat (the device-grant token has it, the refreshed ones would not).
+    my %at_extra = ( grant_type => 'device_code' );
+    $at_extra{_deviceId} = $rtSession->data->{_deviceId}
+      if $rtSession->data->{_deviceId};
     my $access_token =
       $self->oidc->newAccessToken( $req, $rp, $scope, $rtSession->data,
-        { grant_type => 'device_code' } );
+        \%at_extra );
 
     unless ($access_token) {
         $self->logger->error('PAM heartbeat: failed to mint access token');
@@ -1261,7 +1273,12 @@ sub bastionToken {
     # valid device-grant token with the pam scope (steps 1-3), which is all that
     # is required to learn its own bastion_id. The bastion-group distinction is
     # enforced where it matters — voucher minting in /pam/authorize — not here.
-    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
+    # Prefer the per-device identifier (stamped at enrollment by the
+    # oidc-device-organization plugin) so a project-wide client_id still yields a
+    # unique id per bastion; fall back to client_id for legacy enrollments.
+    my $bastion_id = $tokenSession->data->{_deviceId}
+      || $tokenSession->data->{client_id}
+      || 'unknown';
 
     # 5. Parse JSON request body
     my $body = eval { from_json( $req->content ) };
@@ -1914,7 +1931,12 @@ sub bastionCert {
     return $self->_forbiddenResponse( $req, 'Invalid token scope' )
       unless $scope =~ /\bpam(?::server)?\b/;
 
-    my $bastion_id = $tokenSession->data->{client_id} || 'unknown';
+    # Prefer the per-device identifier (stamped at enrollment by the
+    # oidc-device-organization plugin) so a project-wide client_id still yields a
+    # unique id per bastion; fall back to client_id for legacy enrollments.
+    my $bastion_id = $tokenSession->data->{_deviceId}
+      || $tokenSession->data->{client_id}
+      || 'unknown';
 
     # NB: we deliberately do NOT re-derive or require a "bastion group" here.
     # The only security property that matters at this endpoint — a bastion may

--- a/plugins/pam-access/plugin.json
+++ b/plugins/pam-access/plugin.json
@@ -12,6 +12,7 @@
   "customPlugins": "::Plugins::PamAccess",
   "test_depends": [
     "oidc-device-authorization",
+    "oidc-device-organization",
     "ssh-ca"
   ],
   "tags": [

--- a/plugins/pam-access/t/09-PamAccess-DeviceId.t
+++ b/plugins/pam-access/t/09-PamAccess-DeviceId.t
@@ -90,6 +90,10 @@ isnt( $id_a, 'pam-access',
 isnt( $id_b, 'pam-access', 'bastion_id B is the per-device id' );
 isnt( $id_a, $id_b, 'two enrolled devices get DISTINCT device-ids' );
 
+# The device-id is a SHA-256 digest of the synthetic session id, never the raw
+# session id (which is a live credential replayable as a `lemonldap` cookie).
+like( $id_a, qr/\A[0-9a-f]{64}\z/, 'device-id is a SHA-256 hex digest' );
+
 # ---------------------------------------------------------------------------
 # The device-id must SURVIVE a heartbeat refresh: in production the bastion's
 # access token expires and is re-minted via /pam/heartbeat from the refresh

--- a/plugins/pam-access/t/09-PamAccess-DeviceId.t
+++ b/plugins/pam-access/t/09-PamAccess-DeviceId.t
@@ -1,0 +1,161 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+    use FindBin;
+    require "$FindBin::Bin/pam-lib.pm";
+    pam_lib::install_plugin_templates();
+}
+
+# With oidc-device-organization, each enrolled device gets its own synthetic
+# session whose id is stamped as `_deviceId` into the tokens. PamAccess then uses
+# that as the bastion_id — so a single project-wide client_id still yields a
+# UNIQUE identifier per bastion (what a backend allowlist pins on). This test
+# proves the device-id is present, distinct from the shared client_id, and unique
+# per enrollment.
+
+my $debug = 'error';
+my ( $op, $res );
+
+ok(
+    $op = LLNG::Manager::Test->new( {
+            ini => {
+                logLevel => $debug,
+                domain   => 'op.com',
+                portal   => 'http://auth.op.com',
+                pam_lib::base_config(),
+
+                # Add device-organization on top of base_config's plugins.
+                customPlugins =>
+'::Plugins::PamAccess ::Plugins::OIDCDeviceAuthorization ::Plugins::OIDCDeviceOrganization',
+
+                # Make the RP organization-owned so enrollment stamps a per-device
+                # synthetic session (full RP options: a hash key overrides
+                # base_config's, so we restate the essentials + ownership).
+                oidcRPMetaDataOptions => {
+                    'pam-access' => {
+                        oidcRPMetaDataOptionsDisplayName  => 'PAM Access',
+                        oidcRPMetaDataOptionsClientID     => 'pam-access',
+                        oidcRPMetaDataOptionsClientSecret => 'pamsecret',
+                        oidcRPMetaDataOptionsAccessTokenExpiration    => 600,
+                        oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                        oidcRPMetaDataOptionsAllowOffline             => 1,
+                        oidcRPMetaDataOptionsDeviceOwnership => 'organization',
+                    }
+                },
+                pamAccessSshRules      => { default => '1', bastion => '1' },
+                pamAccessBastionGroups => 'bastion',
+            }
+        }
+    ),
+    'OP with pam-access + device-organization (org-owned RP)'
+);
+
+# Probe /pam/bastion-token (no voucher/ssh-ca needed) → returns bastion_id.
+sub probe_bastion_id {
+    my ($token) = @_;
+    my $body = to_json( { probe => JSON::true(), target_group => 'bastion' } );
+    my $r    = $op->_post(
+        '/pam/bastion-token',
+        IO::String->new($body),
+        accept => 'application/json',
+        type   => 'application/json',
+        length => length($body),
+        custom => { HTTP_AUTHORIZATION => "Bearer $token" },
+    );
+    is( $r->[0], 200, '  -> probe returns 200' ) or diag explain $r;
+    return from_json( $r->[2]->[0] )->{bastion_id};
+}
+
+my $sid = $op->login('french');
+
+# Two separate enrollments → two distinct synthetic device sessions.
+my $tok_a = pam_lib::enroll_server( $op, $sid );
+ok( $tok_a, 'enrolled device A' );
+my $tok_b = pam_lib::enroll_server( $op, $sid );
+ok( $tok_b, 'enrolled device B' );
+
+my $id_a = probe_bastion_id($tok_a);
+my $id_b = probe_bastion_id($tok_b);
+
+ok( $id_a, "device A bastion_id present ($id_a)" );
+ok( $id_b, "device B bastion_id present ($id_b)" );
+isnt( $id_a, 'pam-access',
+    'bastion_id A is the per-device id, NOT the shared client_id' );
+isnt( $id_b, 'pam-access', 'bastion_id B is the per-device id' );
+isnt( $id_a, $id_b, 'two enrolled devices get DISTINCT device-ids' );
+
+# ---------------------------------------------------------------------------
+# The device-id must SURVIVE a heartbeat refresh: in production the bastion's
+# access token expires and is re-minted via /pam/heartbeat from the refresh
+# token. newAccessToken() only persists its $info hash, so the heartbeat must
+# carry _deviceId explicitly — otherwise bastion_id would revert to client_id.
+# ---------------------------------------------------------------------------
+sub enroll_offline {
+    my ($s) = @_;
+    my $q = main::buildForm( {
+            client_id     => 'pam-access',
+            client_secret => 'pamsecret',
+            scope         => 'pam:server offline_access',
+        }
+    );
+    my $r = $op->_post( '/oauth2/device', IO::String->new($q),
+        accept => 'application/json', length => length($q) );
+    die "device auth failed: $r->[0]" unless $r->[0] == 200;
+    my $j  = from_json( $r->[2]->[0] );
+    my $dc = $j->{device_code};
+    ( my $uc = $j->{user_code} ) =~ s/-//g;
+    $r = $op->_get( '/device', query => "user_code=$uc",
+        cookie => "lemonldap=$s", accept => 'text/html' );
+    my ($csrf) = $r->[2]->[0] =~ m/name="token"\s+value="([^"]+)"/;
+    $q = main::buildForm(
+        { user_code => $uc, action => 'approve', token => $csrf } );
+    $op->_post( '/device', IO::String->new($q),
+        cookie => "lemonldap=$s", accept => 'text/html', length => length($q) );
+    $q = main::buildForm( {
+            grant_type    => 'urn:ietf:params:oauth:grant-type:device_code',
+            device_code   => $dc,
+            client_id     => 'pam-access',
+            client_secret => 'pamsecret',
+        }
+    );
+    $r = $op->_post( '/oauth2/token', IO::String->new($q),
+        accept => 'application/json', length => length($q) );
+    die "token exchange failed: $r->[0]" unless $r->[0] == 200;
+    $j = from_json( $r->[2]->[0] );
+    return ( $j->{access_token}, $j->{refresh_token} );
+}
+
+my ( $tok_c, $rt_c ) = enroll_offline($sid);
+ok( $rt_c, 'enrolled device C with a refresh token (offline_access)' );
+my $id_c = probe_bastion_id($tok_c);
+isnt( $id_c, 'pam-access', 'device C device-grant token carries the device-id' );
+
+my $hb_body = to_json( {
+        refresh_token => $rt_c,
+        hostname      => 'bastionC.op.com',
+        server_group  => 'bastion',
+        version       => '0.4.1',
+        node_role     => 'bastion',
+    }
+);
+my $r = $op->_post(
+    '/pam/heartbeat',
+    IO::String->new($hb_body),
+    accept => 'application/json',
+    type   => 'application/json',
+    length => length($hb_body),
+);
+is( $r->[0], 200, 'heartbeat returns 200' ) or diag explain $r;
+my $tok_hb = from_json( $r->[2]->[0] )->{access_token};
+ok( $tok_hb, 'heartbeat minted a fresh access token' );
+my $id_hb = probe_bastion_id($tok_hb);
+is( $id_hb, $id_c,
+    'device-id SURVIVES the heartbeat refresh (not reverted to client_id)' );
+
+done_testing();


### PR DESCRIPTION
## Context

Follow-up to #35. Under the realistic Open Bastion model, a single OIDC `client_id` is shared by every machine of a *project*, so `client_id` no longer identifies an individual bastion. The `(bastion_id, user)` voucher binding and a backend's allowed-bastions allowlist therefore had nothing unique to pin on.

## Change

Carry a stable **per-device identifier** end-to-end, derived from the synthetic per-device session that `oidc-device-organization` already creates at enrollment:

- **oidc-device-organization** — stamp the synthetic session id on the token session as `_deviceId` (one synthetic session per enrolled device → stable & unique).
- **oidc-device-authorization** — `_generateTokens` forwards `_deviceId` into the access-token session (`newAccessToken` only persists `$access_token_extra`, hence the explicit forward).
- **pam-access** — `/pam/authorize`, `/pam/bastion-token` and `/pam/bastion-cert` prefer `_deviceId` as the `server_id` / `bastion_id`, falling back to `client_id` for legacy enrollments. `/pam/heartbeat` re-carries `_deviceId` into the refreshed access token, so the id **survives refreshes** instead of reverting to the shared `client_id` after the first heartbeat.

Backward compatible: enrollments without `_deviceId` (legacy, non-org-owned RP) keep using `client_id`.

## Tests

New `t/09-PamAccess-DeviceId.t` proves the device-id is present, distinct from the shared `client_id`, unique per enrollment, and survives a heartbeat refresh. `oidc-device-organization` declared in pam-access `test_depends`.

```
node mcp/cli.js test pam-access              →  Files=9, Tests=568, PASS
node mcp/cli.js test oidc-device-authorization →  Files=3, Tests=170, PASS
```
(`oidc-device-organization` has no `t/` suite of its own; it is exercised end-to-end by `09-PamAccess-DeviceId.t`.)