### PR TITLE
fix(oidc-device-authorization): device sessions broken under hashedSessionStore

### DIFF
--- a/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
+++ b/plugins/oidc-device-authorization/lib/Lemonldap/NG/Portal/Plugins/OIDCDeviceAuthorization.pm
@@ -219,6 +219,12 @@ sub deviceAuthorizationEndpoint {
             $user_code_hash,
             kind   => sessionKind,
             noInfo => 1,
+
+            # These device-authorization sessions are stored under a fixed id
+            # (the SHA-256 of the code), created with hashStore => 0; every
+            # lookup must opt out of hashedSessionStore too, or it would search
+            # under sha256_hex(id) and never find them.
+            hashStore => 0,
         );
 
         if ( !$existing ) {
@@ -684,7 +690,8 @@ sub _findByUserCode {
     my $user_code_hash = sha256_hex($user_code);
 
     my $user_code_session =
-      $self->p->getApacheSession( $user_code_hash, kind => sessionKind, );
+      $self->p->getApacheSession( $user_code_hash, kind => sessionKind,
+        hashStore => 0, );
 
     unless ( $user_code_session && $user_code_session->data ) {
         $self->logger->debug("User code session not found: $user_code");
@@ -713,7 +720,8 @@ sub _getDeviceAuthByHash {
     my ( $self, $device_code_hash ) = @_;
 
     my $session =
-      $self->p->getApacheSession( $device_code_hash, kind => sessionKind, );
+      $self->p->getApacheSession( $device_code_hash, kind => sessionKind,
+        hashStore => 0, );
 
     unless ( $session && $session->data ) {
         $self->logger->debug("Device auth session not found");
@@ -754,8 +762,9 @@ sub _updateDeviceAuthStatus {
     # Update session
     $self->p->getApacheSession(
         $session->id,
-        kind => sessionKind,
-        info => $info,
+        kind      => sessionKind,
+        info      => $info,
+        hashStore => 0,
     );
 }
 
@@ -771,7 +780,8 @@ sub _deleteDeviceAuth {
     if ( my $user_code = $device_auth->{user_code} ) {
         my $user_code_hash = sha256_hex($user_code);
         my $user_code_session =
-          $self->p->getApacheSession( $user_code_hash, kind => sessionKind, );
+          $self->p->getApacheSession( $user_code_hash, kind => sessionKind,
+            hashStore => 0, );
         $user_code_session->remove if $user_code_session;
     }
 }

--- a/plugins/oidc-device-authorization/t/35-Device-HashedSessionStore.t
+++ b/plugins/oidc-device-authorization/t/35-Device-HashedSessionStore.t
@@ -1,0 +1,118 @@
+use warnings;
+use Test::More;
+use strict;
+use IO::String;
+use JSON;
+
+BEGIN {
+    require 't/test-lib.pm';
+    require 't/oidc-lib.pm';
+}
+
+# Regression: the device-authorization user_code/device_code sessions are stored
+# under a fixed id (the SHA-256 of the code) with hashStore => 0. The lookups
+# used to omit hashStore => 0, so with hashedSessionStore enabled getApacheSession
+# searched under sha256_hex(id) and never found them — the verification page
+# could not resolve the user_code, approval silently failed, and the token
+# exchange returned `expired_token`. This test runs the full RFC 8628 flow with
+# hashedSessionStore on and asserts it succeeds end to end.
+
+my $debug = 'error';
+
+my $op = LLNG::Manager::Test->new( {
+        ini => {
+            logLevel                        => $debug,
+            domain                          => 'op.com',
+            portal                          => 'http://auth.op.com/',
+            authentication                  => 'Demo',
+            userDB                          => 'Same',
+            issuerDBOpenIDConnectActivation => 1,
+            customPlugins                   => '::Plugins::OIDCDeviceAuthorization',
+
+            # The setting under test.
+            hashedSessionStore => 1,
+
+            oidcServiceDeviceAuthorizationExpiration       => 600,
+            oidcServiceDeviceAuthorizationPollingInterval  => 5,
+            oidcServiceDeviceAuthorizationUserCodeLength   => 8,
+            oidcRPMetaDataOptions                          => {
+                rp => {
+                    oidcRPMetaDataOptionsDisplayName              => "RP",
+                    oidcRPMetaDataOptionsIDTokenExpiration        => 3600,
+                    oidcRPMetaDataOptionsIDTokenSignAlg           => "RS256",
+                    oidcRPMetaDataOptionsClientID                 => "rpid",
+                    oidcRPMetaDataOptionsPublic                   => 1,
+                    oidcRPMetaDataOptionsUserIDAttr               => "",
+                    oidcRPMetaDataOptionsAccessTokenExpiration    => 3600,
+                    oidcRPMetaDataOptionsBypassConsent            => 1,
+                    oidcRPMetaDataOptionsRefreshToken             => 1,
+                    oidcRPMetaDataOptionsAllowOffline             => 1,
+                    oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                },
+            },
+            oidcServicePrivateKeySig => oidc_key_op_private_sig,
+            oidcServicePublicKeySig  => oidc_cert_op_public_sig,
+        }
+    }
+);
+
+my $res;
+
+# 1. Device authorization request
+my $query = buildForm( { client_id => 'rpid', scope => 'openid profile' } );
+$res = $op->_post( "/oauth2/device", IO::String->new($query),
+    accept => 'application/json', length => length($query) );
+my $payload = expectJSON($res);
+ok( $payload->{device_code}, "Got device_code (hashedSessionStore)" );
+ok( $payload->{user_code},   "Got user_code (hashedSessionStore)" );
+count(2);
+
+my $device_code = $payload->{device_code};
+my $user_code   = $payload->{user_code};
+
+# 2. Login and open the verification page — this is the lookup that failed:
+#    the user_code session must be found under hashedSessionStore.
+my $id = login( $op, 'french' );
+$res = $op->_get( "/device",
+    query  => "user_code=" . ( $user_code =~ s/-//gr ),
+    cookie => "lemonldap=$id", accept => 'text/html' );
+expectOK($res);
+like( $res->[2]->[0], qr/deviceform/,
+    "Verification page resolves the user_code (session found)" );
+count(1);
+
+my ($csrf) =
+  $res->[2]->[0] =~ m%<input type="hidden" name="token" value="([\d_]+?)" />%;
+ok( $csrf, "Got CSRF token" );
+count(1);
+
+# 3. Approve the device.
+$query = buildForm( {
+        user_code => ( $user_code =~ s/-//gr ),
+        action    => 'approve',
+        token     => $csrf,
+    }
+);
+$res = $op->_post( "/device", IO::String->new($query),
+    cookie => "lemonldap=$id", accept => 'text/html', length => length($query) );
+expectOK($res);
+like( $res->[2]->[0], qr/deviceApproved|success/, "Device approved" );
+count(1);
+
+# 4. Exchange the device_code — the regression: this used to return
+#    expired_token because the device_auth session could not be found.
+$query = buildForm( {
+        grant_type  => 'urn:ietf:params:oauth:grant-type:device_code',
+        device_code => $device_code,
+        client_id   => 'rpid',
+    }
+);
+$res = $op->_post( "/oauth2/token", IO::String->new($query),
+    accept => 'application/json', length => length($query) );
+$payload = expectJSON($res);
+is( $res->[0], 200, "Token exchange succeeds under hashedSessionStore" );
+ok( $payload->{access_token}, "Got access_token" );
+ok( $payload->{id_token},     "Got id_token" );
+count(3);
+
+done_testing();

--- a/plugins/oidc-device-authorization/t/35-Device-HashedSessionStore.t
+++ b/plugins/oidc-device-authorization/t/35-Device-HashedSessionStore.t
@@ -115,4 +115,5 @@ ok( $payload->{access_token}, "Got access_token" );
 ok( $payload->{id_token},     "Got id_token" );
 count(3);
 
+clean_sessions();
 done_testing();

--- a/plugins/pam-access/t/09-PamAccess-DeviceId.t
+++ b/plugins/pam-access/t/09-PamAccess-DeviceId.t
@@ -211,4 +211,5 @@ is( $id_hb, $id_c,
         'device-id is the per-device id, not the shared client_id' );
 }
 
+clean_sessions();
 done_testing();

--- a/plugins/pam-access/t/09-PamAccess-DeviceId.t
+++ b/plugins/pam-access/t/09-PamAccess-DeviceId.t
@@ -58,9 +58,10 @@ ok(
 
 # Probe /pam/bastion-token (no voucher/ssh-ca needed) → returns bastion_id.
 sub probe_bastion_id {
-    my ($token) = @_;
+    my ( $token, $opx ) = @_;
+    $opx ||= $op;
     my $body = to_json( { probe => JSON::true(), target_group => 'bastion' } );
-    my $r    = $op->_post(
+    my $r    = $opx->_post(
         '/pam/bastion-token',
         IO::String->new($body),
         accept => 'application/json',
@@ -161,5 +162,53 @@ ok( $tok_hb, 'heartbeat minted a fresh access token' );
 my $id_hb = probe_bastion_id($tok_hb);
 is( $id_hb, $id_c,
     'device-id SURVIVES the heartbeat refresh (not reverted to client_id)' );
+
+# ---------------------------------------------------------------------------
+# End-to-end under hashedSessionStore: the org-device bastion enrollment that
+# first surfaced the device-authorization session-lookup bug must now work, and
+# the device-id (derived from the cleartext session id, domain-separated) stays
+# a valid per-device identifier in this storage mode.
+# ---------------------------------------------------------------------------
+{
+    my $op2;
+    ok(
+        $op2 = LLNG::Manager::Test->new( {
+                ini => {
+                    logLevel           => $debug,
+                    domain             => 'op.com',
+                    portal             => 'http://auth.op.com',
+                    hashedSessionStore => 1,
+                    pam_lib::base_config(),
+                    customPlugins =>
+'::Plugins::PamAccess ::Plugins::OIDCDeviceAuthorization ::Plugins::OIDCDeviceOrganization',
+                    oidcRPMetaDataOptions => {
+                        'pam-access' => {
+                            oidcRPMetaDataOptionsDisplayName  => 'PAM Access',
+                            oidcRPMetaDataOptionsClientID     => 'pam-access',
+                            oidcRPMetaDataOptionsClientSecret => 'pamsecret',
+                            oidcRPMetaDataOptionsAccessTokenExpiration => 600,
+                            oidcRPMetaDataOptionsAllowDeviceAuthorization => 1,
+                            oidcRPMetaDataOptionsAllowOffline             => 1,
+                            oidcRPMetaDataOptionsDeviceOwnership => 'organization',
+                        }
+                    },
+                    pamAccessSshRules      => { default => '1', bastion => '1' },
+                    pamAccessBastionGroups => 'bastion',
+                }
+            }
+        ),
+        'OP with hashedSessionStore enabled'
+    );
+
+    my $hsid  = $op2->login('french');
+    my $tok_h = pam_lib::enroll_server( $op2, $hsid );
+    ok( $tok_h, 'org-device enrollment succeeds under hashedSessionStore' );
+    my $id_h = probe_bastion_id( $tok_h, $op2 );
+    ok( $id_h, "device-id present under hashedSessionStore ($id_h)" );
+    like( $id_h, qr/\A[0-9a-f]{64}\z/,
+        'device-id is still a SHA-256 hex digest under hashedSessionStore' );
+    isnt( $id_h, 'pam-access',
+        'device-id is the per-device id, not the shared client_id' );
+}
 
 done_testing();


### PR DESCRIPTION
Fixes #38

## Problem

When `hashedSessionStore` is enabled, **every** OIDC device-grant enrollment fails: the verification page returns "user_code session not found", approval silently fails, and the token exchange returns `expired_token`.

Root cause: the `user_code` / `device_code` device-authorization sessions are stored under a **fixed id** (the SHA-256 of the code) and created with `hashStore => 0` — but the corresponding **lookups/updates/removals omitted `hashStore => 0`**. With `hashedSessionStore` on, `getApacheSession` then hashes the id again and searches under `sha256_hex(id)`, so it never finds the sessions created under the raw id.

This is what broke org-device bastion enrollment under `hashedSessionStore` (found while working on the per-device `bastion_id` PR #36).

## Fix

Force `hashStore => 0` on all fixed-id session call sites in `OIDCDeviceAuthorization.pm` (collision check, user_code lookup, device_code lookup, update, delete), so they match how these sessions are created.

The user-session lookup `getApacheSession($user_session_id)` in `_generateTokens` is deliberately **left untouched** — it is a real SSO/synthetic session that must respect `hashedSessionStore`.

## Tests

- **oidc-device-authorization** — new `t/35-Device-HashedSessionStore.t` runs the full RFC 8628 flow with `hashedSessionStore => 1` and asserts the verification page resolves the code, approval succeeds, and the token exchange returns 200 + tokens.
- **pam-access** — `t/09-PamAccess-DeviceId.t` gains an end-to-end org-device bastion enrollment under `hashedSessionStore` (the exact scenario that surfaced the bug).

```
node mcp/cli.js test oidc-device-authorization  →  Files=4, Tests=191, PASS
node mcp/cli.js test pam-access                  →  Files=9, Tests=573, PASS
```