### PR TITLE
fix(pam-access): reuse the bastion voucher across concurrent sessions

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -528,7 +528,17 @@ sub authorize {
         # short-lived certs for THIS user only — closing the hole where a
         # bastion could vouch for any user it never saw. Bound to the user's
         # SSO cert lifetime when a fingerprint matched above.
-        if ( $self->_isBastionGroup($server_group) ) {
+        #
+        # Only the interactive SSH login mints (and thus rotates) the voucher.
+        # A sudo elevation on the bastion ('sudo'/'sudo-i', canonicalized to
+        # 'sudo' by the PAM module) also reaches /pam/authorize, but minting
+        # there would generate a fresh nonce and overwrite the one already
+        # exported into the user's login shell — which then fails at
+        # /pam/bastion-cert with voucher_mismatch. Gate minting on the login
+        # service so a sudo authorization check has no voucher side effect.
+        if (   $self->_isBastionGroup($server_group)
+            && $self->_isVoucherMintingService($service) )
+        {
             my ( $nonce, $vexp ) = $self->_mintBastionVoucher(
                 $req, $user, $server_id,
                 ( $sshCheck && $sshCheck->{ok} )
@@ -1825,18 +1835,29 @@ sub _isBastionGroup {
     return 0;
 }
 
+# Whether the PAM service that triggered this /pam/authorize is allowed to mint
+# (and therefore rotate) the bastion voucher. Only the interactive SSH login
+# should: it is the one whose minted nonce is exported into the user's shell
+# environment. Other services that also authorize for the same (bastion_id,
+# user) — notably sudo/sudo-i — must leave the existing voucher untouched, or
+# they rotate the nonce and break the voucher already handed to the login shell
+# (the bastion then fails at /pam/bastion-cert with voucher_mismatch).
+# Configurable via pamAccessBastionVoucherServices (default: "sshd ssh").
+sub _isVoucherMintingService {
+    my ( $self, $service ) = @_;
+    return 0 unless defined $service && $service ne '';
+    my $services = $self->conf->{pamAccessBastionVoucherServices} || 'sshd ssh';
+    for my $allowed ( split /[,;\s]+/, $services ) {
+        return 1 if $service eq $allowed;
+    }
+    return 0;
+}
+
 # Mint (replace) a reusable (bastion_id, user) voucher in the user's persistent
 # session. Validity is capped by the user's SSO cert expiry when known, else by
 # pamAccessBastionVoucherTtl (default 12h). Returns ($nonce, $exp) or ().
 sub _mintBastionVoucher {
     my ( $self, $req, $user, $bastion_id, $cert_expires_at ) = @_;
-
-    my $nonce = $self->_generateUUID();
-    unless ($nonce) {
-        $self->logger->error(
-            'PAM authorize: cannot generate bastion voucher nonce');
-        return ();
-    }
 
     my $now    = time();
     my $ttlCap =
@@ -1862,6 +1883,32 @@ sub _mintBastionVoucher {
         delete $vmap->{$k}
           if ref $vmap->{$k} ne 'HASH' || ( $vmap->{$k}{exp} || 0 ) <= $now;
     }
+
+    # Idempotent reuse. A user routinely holds several concurrent sessions on
+    # the same bastion, and the (bastion_id, user) voucher is shared across all
+    # of them (it is keyed per bastion, not per session). Minting a fresh nonce
+    # on every /pam/authorize would overwrite the nonce already exported into
+    # the other live sessions' shells, which then fail at /pam/bastion-cert with
+    # voucher_mismatch (symptom: "works only from the most recent login"). So
+    # keep an existing still-valid nonce and only extend its expiry; generate a
+    # new nonce solely when none is usable (the prune above already dropped any
+    # expired entry for this bastion_id).
+    my $existing = $vmap->{$bastion_id};
+    my $nonce;
+    if ( $existing && ( $existing->{nonce} // '' ) ne '' ) {
+        $nonce = $existing->{nonce};
+        $exp   = $existing->{exp}
+          if ( $existing->{exp} || 0 ) > $exp;    # never shorten a live voucher
+    }
+    else {
+        $nonce = $self->_generateUUID();
+        unless ($nonce) {
+            $self->logger->error(
+                'PAM authorize: cannot generate bastion voucher nonce');
+            return ();
+        }
+    }
+
     $vmap->{$bastion_id} = { nonce => $nonce, exp => $exp };
     $ps->update( { _pamBastionVouchers => to_json($vmap) } );
 
@@ -2365,6 +2412,16 @@ This ensures that the PAM module is still active on the server. (default: 0)
 Comma/space-separated list of server groups considered bastions
 (default: 'bastion'). Members of these groups get a bastion voucher from
 C</pam/authorize> and may call C</pam/bastion-cert>.
+
+=item pamAccessBastionVoucherServices
+
+Comma/space-separated list of PAM service names whose C</pam/authorize> call
+is allowed to mint (and rotate) the bastion voucher (default: 'sshd ssh').
+Only the interactive SSH login should mint, since its nonce is exported into
+the user's shell. Other services that also authorize for the same bastion and
+user — notably C<sudo>/C<sudo-i> — must be excluded, otherwise they rotate the
+nonce and invalidate the voucher already held by the login shell (which then
+fails at C</pam/bastion-cert> with C<voucher_mismatch>).
 
 =item pamAccessBastionVoucherTtl
 

--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -529,13 +529,12 @@ sub authorize {
         # bastion could vouch for any user it never saw. Bound to the user's
         # SSO cert lifetime when a fingerprint matched above.
         #
-        # Only the interactive SSH login mints (and thus rotates) the voucher.
-        # A sudo elevation on the bastion ('sudo'/'sudo-i', canonicalized to
-        # 'sudo' by the PAM module) also reaches /pam/authorize, but minting
-        # there would generate a fresh nonce and overwrite the one already
-        # exported into the user's login shell — which then fails at
-        # /pam/bastion-cert with voucher_mismatch. Gate minting on the login
-        # service so a sudo authorization check has no voucher side effect.
+        # Only the interactive SSH login issues a voucher. A sudo elevation on
+        # the bastion ('sudo'/'sudo-i', canonicalized to 'sudo' by the PAM
+        # module) also reaches /pam/authorize, but a sudo authorization check
+        # must have no voucher side effect at all — neither rotating the stored
+        # nonce nor returning one in the response. Gate issuance on the login
+        # service so sudo stays voucher-free.
         if (   $self->_isBastionGroup($server_group)
             && $self->_isVoucherMintingService($service) )
         {
@@ -549,7 +548,7 @@ sub authorize {
                 $response->{bastion_voucher}            = $nonce;
                 $response->{bastion_voucher_expires_in} = $vexp - time();
                 $self->logger->debug(
-"PAM authorize: minted bastion voucher for user '$user' (bastion='$server_id', exp=$vexp)"
+"PAM authorize: issued bastion voucher for user '$user' (bastion='$server_id', exp=$vexp)"
                 );
             }
         }
@@ -1853,9 +1852,11 @@ sub _isVoucherMintingService {
     return 0;
 }
 
-# Mint (replace) a reusable (bastion_id, user) voucher in the user's persistent
-# session. Validity is capped by the user's SSO cert expiry when known, else by
-# pamAccessBastionVoucherTtl (default 12h). Returns ($nonce, $exp) or ().
+# Ensure a reusable (bastion_id, user) voucher exists in the user's persistent
+# session: reuse the current still-valid nonce when present (only extending its
+# expiry), otherwise generate a fresh one. Validity is capped by the user's SSO
+# cert expiry when known, else by pamAccessBastionVoucherTtl (default 12h).
+# Returns ($nonce, $exp) or ().
 sub _mintBastionVoucher {
     my ( $self, $req, $user, $bastion_id, $cert_expires_at ) = @_;
 

--- a/plugins/pam-access/t/08-PamAccess-BastionCert.t
+++ b/plugins/pam-access/t/08-PamAccess-BastionCert.t
@@ -364,6 +364,41 @@ $res = bastion_post(
 is( $res->[0], 200, 'same voucher reused for a second hop -> 200' );
 
 # ============================================================================
+# Concurrent sessions: a user routinely holds several SSH logins on the same
+# bastion at once. The voucher is keyed per (bastion_id, user), so a second
+# login's /pam/authorize must REUSE the existing nonce, not rotate it -- else
+# the first session's already-exported voucher would start failing with
+# voucher_mismatch ("works only from the most recent login").
+{
+    $res = bastion_post( '/pam/authorize',
+        { user => 'french', server_group => 'bastion', host => 'b1', service => 'sshd' } );
+    is( $res->[0], 200, 'second concurrent login /pam/authorize -> 200' );
+    my $v2 = from_json( $res->[2]->[0] )->{bastion_voucher};
+    is( $v2, $voucher, '  -> reuses the same voucher nonce (no rotation)' );
+
+    # And a sudo elevation must not mint/rotate the voucher at all.
+    $res = bastion_post( '/pam/authorize',
+        { user => 'french', server_group => 'bastion', host => 'b1', service => 'sudo' } );
+    is( $res->[0], 200, 'sudo /pam/authorize -> 200' );
+    my $a = from_json( $res->[2]->[0] );
+    ok( !exists $a->{bastion_voucher},
+        '  -> sudo does not mint a voucher' );
+
+    # The original login voucher is still valid after both -> not rotated.
+    $res = bastion_post(
+        '/pam/bastion-cert',
+        {
+            user        => 'french',
+            target_host => 'backend9.op.com',
+            public_key  => $eph_pubkey,
+            voucher     => $voucher,
+        }
+    );
+    is( $res->[0], 200,
+        'login voucher still valid after a concurrent login + sudo -> 200' );
+}
+
+# ============================================================================
 # pamAccessBastionCertPinSourceAddress = 0 drops the source-address pin
 # (for deployments where the IP LLNG observes is not the bastion's SSH egress
 # address: portal behind a reverse proxy, multi-homed bastion, NAT, ...).


### PR DESCRIPTION
## Problem

A user routinely holds **several concurrent SSH logins on the same bastion**, each spawning an `ob-ssh` to a backend. The bastion voucher is keyed by `(bastion_id, user)` — so it is **shared** across all of those sessions, not per-session.

The old code minted a **fresh nonce on every `/pam/authorize`**, overwriting the nonce already exported into the other live sessions' shells (`LLNG_BASTION_VOUCHER`). Those sessions then failed at `/pam/bastion-cert` with `voucher_mismatch`. Typical symptom: "works only from the most recent login".

## Fix

- **Idempotent reuse** (`_mintBastionVoucher`): reuse an existing still-valid nonce and only **extend its expiry** (never shorten a live voucher). A new nonce is generated only when none is usable (expired entries are pruned beforehand).
- **PAM service gating** (`_isVoucherMintingService`, option `pamAccessBastionVoucherServices`, default `"sshd ssh"`): only the interactive SSH login mints/rotates the voucher. A `sudo`/`sudo-i` elevation also reaches `/pam/authorize` but must have **no side effect** on the voucher (no rotation, no voucher in its response).
- New option documented in the POD: `pamAccessBastionVoucherServices`.

## Tests

Coverage added in `t/08-PamAccess-BastionCert.t`: a second concurrent login reusing the nonce, `sudo` not minting, and the original login voucher staying valid after a concurrent login + sudo.

\`\`\`
Files=1, Tests=54 — All tests successful. Result: PASS
\`\`\`

## Note (out of scope)

The "no more `ob-ssh` the next day, OK after a reboot" symptom belongs to the same family (the voucher snapshot in the shell drifts out of sync with the server-side map) but has a different trigger — **expiry** of the voucher (12h TTL / SSO cert) on a session that was never re-authenticated (tmux, `ControlPersist`, lingering session). This PR does not address it; a fix on the `ob-ssh` side (voucher refresh) would be required.