### PR TITLE
fix(pam-access): bind hop cert fingerprint to a session window, not cert TTL

### DIFF
--- a/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
+++ b/plugins/pam-access/lib/Lemonldap/NG/Portal/Plugins/PamAccess.pm
@@ -1780,14 +1780,27 @@ sub _checkSshFingerprint {
             $self->logger->warn(
                 "PAM verify: corrupted ephemeral cert record for $user: $@");
         }
-        elsif ( !$rec->{expires_at} || $rec->{expires_at} >= $now ) {
-            return {
-                ok         => 1,
-                serial     => $rec->{serial},
-                key_id     => $rec->{key_id},
-                expires_at => $rec->{expires_at},
-                ephemeral  => 1,
-            };
+        else {
+            # Gate acceptance on the BINDING window, not the SSH cert's own
+            # expires_at. The hop cert is deliberately short-lived (~120s,
+            # pamAccessBastionCertTtl) — just long enough for sshd to accept it
+            # at connection time — but the resulting backend SSH session lives
+            # much longer, and a later sudo (fresh OTP) on that still-open
+            # session legitimately presents the same fingerprint. Binding to the
+            # cert's expiry broke sudo a couple of minutes into every session;
+            # bind to binding_expires_at instead (falls back to expires_at for
+            # records minted before this field existed). Still return the real
+            # expires_at so callers (e.g. voucher minting) keep cert semantics.
+            my $bindExp = $rec->{binding_expires_at} || $rec->{expires_at};
+            if ( !$bindExp || $bindExp >= $now ) {
+                return {
+                    ok         => 1,
+                    serial     => $rec->{serial},
+                    key_id     => $rec->{key_id},
+                    expires_at => $rec->{expires_at},
+                    ephemeral  => 1,
+                };
+            }
         }
     }
 
@@ -2103,6 +2116,16 @@ sub bastionCert {
         $clean->($bastion_id), $clean->($user), $clean->($target_host) );
 
     my $ttl    = $self->_confPositiveInt( 'pamAccessBastionCertTtl', 120 );
+
+    # Binding window: how long the backend's SSH-fingerprint check
+    # (_checkSshFingerprint) keeps accepting this hop cert's fingerprint for a
+    # still-open session — independent of the SSH cert's own (short) validity.
+    # Must cover a realistic backend session (default 24h); never shorter than
+    # the cert TTL.
+    my $bindingTtl =
+      $self->_confPositiveInt( 'pamAccessBastionBindingTtl', 86400 );
+    $bindingTtl = $ttl if $bindingTtl < $ttl;
+
     my $serial = $sshca->_getNextSerial;
     my %signOpts = ( validity => "+${ttl}s" );
 
@@ -2152,10 +2175,11 @@ sub bastionCert {
         my %upd  = (
             $EPH_CERT_PREFIX . $eph_fp => to_json(
                 {
-                    serial     => $serial,
-                    key_id     => $keyId,
-                    issued_at  => $now,
-                    expires_at => $now + $ttl,
+                    serial             => $serial,
+                    key_id             => $keyId,
+                    issued_at          => $now,
+                    expires_at         => $now + $ttl,
+                    binding_expires_at => $now + $bindingTtl,
                 }
             )
         );
@@ -2163,10 +2187,17 @@ sub bastionCert {
             next unless index( $k, $EPH_CERT_PREFIX ) == 0;
             next if $k eq $EPH_CERT_PREFIX . $eph_fp;
             my $r = eval { from_json( $ps->data->{$k} // '' ) };
+            # Drop on the binding window (fallback to the cert expiry for
+            # pre-existing records), matching _checkSshFingerprint's acceptance
+            # rule — otherwise we would prune entries that are still bindable.
+            my $rexp =
+              ref($r) eq 'HASH'
+              ? ( $r->{binding_expires_at} || $r->{expires_at} )
+              : undef;
             $upd{$k} = undef
               if $@
               || ref($r) ne 'HASH'
-              || ( $r->{expires_at} && $r->{expires_at} < $now );
+              || ( $rexp && $rexp < $now );
         }
         $ps->update( \%upd );
     }
@@ -2446,6 +2477,21 @@ known. Must be a positive integer; invalid values fall back to the default.
 Validity of the ephemeral certificates issued by C</pam/bastion-cert>, in
 seconds (default: 120). Must be a positive integer; invalid values fall
 back to the default.
+
+=item pamAccessBastionBindingTtl
+
+How long a hop certificate's fingerprint stays bindable on the target
+backend, in seconds (default: 86400, i.e. 24h). This is independent of
+C<pamAccessBastionCertTtl>: the SSH certificate is short-lived (just long
+enough for sshd to accept the connection), but the resulting backend SSH
+session lives much longer, and a later C<sudo> on that still-open session
+(with a fresh one-time token) must keep validating against the same
+fingerprint. C<_checkSshFingerprint> therefore accepts the fingerprint until
+this binding window elapses rather than until the certificate expires. Must
+be a positive integer; values below C<pamAccessBastionCertTtl> are raised to
+it. Revocation still applies. Only affects hop certificates
+(C</pam/bastion-cert>); direct C<_sshCerts> certificates keep their own
+(longer) validity.
 
 =item pamAccessBastionCertPinSourceAddress
 

--- a/plugins/pam-access/t/08-PamAccess-BastionCert.t
+++ b/plugins/pam-access/t/08-PamAccess-BastionCert.t
@@ -351,6 +351,53 @@ SKIP: {
         'POST /pam/authorize with an unknown fp -> denied (binding intact)' );
 }
 
+# ============================================================================
+# Binding window outlives the hop cert's own (short) validity. Regression for
+# "sudo fails a couple of minutes into a long backend SSH session": the SSH
+# cert's expires_at lapses quickly, but a still-open session must keep
+# validating its fingerprint until binding_expires_at. _checkSshFingerprint
+# must gate on binding_expires_at, not expires_at — while still rejecting once
+# the binding window is closed.
+# ============================================================================
+{
+    my $pam =
+      $op->p->loadedModules->{'Lemonldap::NG::Portal::Plugins::PamAccess'};
+    my $sshca =
+      $op->p->loadedModules->{'Lemonldap::NG::Portal::Plugins::SSHCA'};
+    my $eph_fp = $sshca->_sshKeyFingerprint($eph_pubkey);
+    my $key    = "_pamEphCert::" . $eph_fp;
+
+    my $ps  = $op->p->getPersistentSession('french');
+    my $rec = from_json( $ps->data->{$key} );
+    ok(
+        $rec->{binding_expires_at}
+          && $rec->{binding_expires_at} > $rec->{expires_at},
+        'binding_expires_at is set and outlives the cert expires_at'
+    );
+
+    # Long-open session: the hop cert's validity has lapsed, binding still open.
+    $rec->{expires_at}         = time() - 10;
+    $rec->{binding_expires_at} = time() + 3600;
+    $ps->update( { $key => to_json($rec) } );
+    ok( $pam->_checkSshFingerprint( 'french', $eph_fp )->{ok},
+        'cert expired but binding window open -> fingerprint accepted' );
+
+    # Binding window closed too -> rejected (falls through to _sshCerts).
+    $ps  = $op->p->getPersistentSession('french');
+    $rec = from_json( $ps->data->{$key} );
+    $rec->{binding_expires_at} = time() - 10;
+    $ps->update( { $key => to_json($rec) } );
+    ok( !$pam->_checkSshFingerprint( 'french', $eph_fp )->{ok},
+        'binding window closed -> fingerprint rejected' );
+
+    # Restore a healthy record so the voucher tests below are unaffected.
+    $ps  = $op->p->getPersistentSession('french');
+    $rec = from_json( $ps->data->{$key} );
+    $rec->{expires_at}         = time() + 90;
+    $rec->{binding_expires_at} = time() + 86400;
+    $ps->update( { $key => to_json($rec) } );
+}
+
 # Voucher is REUSABLE (not consumed) -> supports multi-hop / scp host1: host2:
 $res = bastion_post(
     '/pam/bastion-cert',


### PR DESCRIPTION
## Problème

Le certificat de saut (hop cert) émis par `/pam/bastion-cert` est volontairement très court (~120s, `pamAccessBastionCertTtl`) — juste assez pour que `sshd` l'accepte au moment de la connexion. Mais la session SSH backend qui en résulte vit beaucoup plus longtemps, et un `sudo` ultérieur (nouveau OTP) sur cette session toujours ouverte présente légitimement la même empreinte.

Or `_checkSshFingerprint` validait sur le `expires_at` du certificat → le `sudo` échouait deux minutes après le début de chaque session.

## Correctif

- Introduction d'une **fenêtre de liaison** distincte : `pamAccessBastionBindingTtl` (défaut 24h, jamais inférieure au TTL du cert), stockée sous `binding_expires_at` dans l'enregistrement du cert éphémère.
- `_checkSshFingerprint` et la boucle de purge se basent désormais sur `binding_expires_at` (avec repli sur `expires_at` pour les enregistrements antérieurs), tout en continuant de retourner le vrai `expires_at` pour préserver la sémantique du cert lors de l'émission de vouchers.
- La révocation continue de s'appliquer ; seuls les hop certs (`/pam/bastion-cert`) sont concernés — les certs `_sshCerts` directs gardent leur propre validité.

## Tests

Ajout de tests de régression dans `t/08-PamAccess-BastionCert.t` :
- `binding_expires_at` est défini et survit à `expires_at`
- cert expiré mais fenêtre de liaison ouverte → empreinte acceptée
- fenêtre de liaison fermée → empreinte rejetée

Suite complète : **57/57 tests OK**.